### PR TITLE
Add domain glossary and architecture ADRs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,50 @@
+# DTM Ones
+
+A basketball agency that represents Clients. The Roster is the public Clients. Users maintain Clients and inbound ContactRequests from a dashboard.
+
+## Language
+
+### Staff
+
+**User**:
+A person who signs in to the dashboard. A User is either an Owner or a Staff member. A User is not a Client.
+_Avoid_: Admin (as a type of person), account, operator, Client
+
+**Owner**:
+A User who can create other Users, change their role, and delete them.
+_Avoid_: Admin, superuser
+
+**Staff**:
+A User who can manage Clients and ContactRequests and cannot manage Users.
+
+### Roster
+
+**Client**:
+A Player or a Coach the agency represents. A Client is not a User. A Client is exactly one of Player or Coach; the same human doing both is two Clients. A Client has a Visibility.
+_Avoid_: User, talent, represented being, super-entity
+
+**Visibility**:
+Whether a Client is on the Roster. Public means on the Roster. Private means not on the Roster. A Client may be public only when that kind’s profile is complete. Visibility is not a document-draft workflow.
+_Avoid_: draft, published, GitHub
+
+**Roster**:
+The public Clients. A private Client is still a Client, not on the Roster.
+_Avoid_: team, catalog, all Clients, the database of Clients
+
+**Player**:
+A basketball player the agency represents. A Player is a Client, is not a User, does not sign in, and is not a Coach. A Player has at most one Category. A public Player has a complete profile: name, Category, presentation image, height, nationality, and last club. Gallery and videos may be empty.
+_Avoid_: User, account, athlete-as-login, Coach-as-Player
+
+**Coach**:
+A basketball coach the agency represents. A Coach is a Client, is not a Player, is not a User, and does not share a Player’s attributes (height and Category are Player facts). A public Coach has a complete profile: name, nationality, and last club.
+_Avoid_: Player, Player tagged “Coaches”
+
+**Category**:
+A Player’s position on the court. Staff create and rename Categories. A Category cannot be deleted while any Player has it. A Coach does not have a Category.
+_Avoid_: Youths, Coaches-as-Category, tag, filter-bucket, age group, closed position enum
+
+### Inquiries
+
+**ContactRequest**:
+An inbound message from the public contact form, classified by why it was sent, not by who sent it. The two reasons are seeking representation and looking for a player. “Looking for a player” is the hiring reason; it is not a Player record and is not about a specific Client.
+_Avoid_: Contact, lead, ticket, Recruiter (as a person we store), Player (as the sender)

--- a/docs/adr/0001-keep-better-auth.md
+++ b/docs/adr/0001-keep-better-auth.md
@@ -1,0 +1,5 @@
+# Keep Better Auth through the InsForge exit
+
+Dashboard Users are Owner-provisioned identities that already live in our Postgres via Better Auth (`createUser` / `setRole` / `removeUser`, mirrored into `public.users`). We will not move that identity onto InsForge Auth (no Owner-provisioning API) or onto another vendor Auth product when we leave InsForge. Identity then travels with a database dump instead of dying with the Auth vendor.
+
+**Considered:** InsForge Auth (cannot provision Users as an Owner). Supabase Auth (can provision, but Users would no longer be just Postgres we restore elsewhere). Dropping Better Auth was a consolidation preference, not a missing feature.

--- a/docs/adr/0002-neon-and-blob.md
+++ b/docs/adr/0002-neon-and-blob.md
@@ -1,0 +1,5 @@
+# Exit InsForge for Neon Postgres and Vercel Blob
+
+InsForge is a public PostgREST + storage API. Better Auth is the real User session. Those two do not share a token, so staff authorization on the data API is a handmade JWT bridge — a second identity system. We will leave InsForge for Neon (Postgres only) and Vercel Blob (Player images). The Next.js apps are the only processes that talk to Postgres. There is no public data API.
+
+**Considered:** Stay on InsForge and harden RLS (still a vendor we do not want to park on). Move to Supabase and keep PostgREST (same shape, more famous logo; Better Auth still would not be what the API authenticates). Supabase-as-Postgres with REST grants stripped (closes the door, still a BaaS account). Neon + R2/S3 (more portable files; more wiring).


### PR DESCRIPTION
## Summary
- Adds `CONTEXT.md` with the shared domain language (Client, Roster, Visibility, Player, Coach, Category, ContactRequest).
- Adds ADRs for keeping Better Auth and exiting InsForge toward Neon and Vercel Blob.
- Docs only; no product behavior change.

## Test plan
- [x] Nothing to test — markdown only.


Made with [Cursor](https://cursor.com)