### PR TITLE
Let Staff list, create, and edit Coaches on Neon

### DIFF
--- a/apps/dashboard/src/actions/coaches/createCoach.ts
+++ b/apps/dashboard/src/actions/coaches/createCoach.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { db } from "@/lib/db";
+import { staffActionClient } from "@/lib/safe-action";
+import { createCoachSchema } from "@/lib/validation/coaches";
+import { createCoach } from "@/utils/coaches";
+
+export const createCoachAction = staffActionClient
+  .metadata({ actionName: "createCoach" })
+  .inputSchema(createCoachSchema)
+  .action(async ({ parsedInput }) => {
+    const coach = await createCoach(db, parsedInput);
+
+    revalidatePath("/coaches");
+
+    return { ok: true as const, coach };
+  });

--- a/apps/dashboard/src/actions/coaches/setCoachVisibility.ts
+++ b/apps/dashboard/src/actions/coaches/setCoachVisibility.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { db } from "@/lib/db";
+import { staffActionClient } from "@/lib/safe-action";
+import { setCoachVisibilitySchema } from "@/lib/validation/coaches";
+import { setCoachVisibility } from "@/utils/coaches";
+
+export const setCoachVisibilityAction = staffActionClient
+  .metadata({ actionName: "setCoachVisibility" })
+  .inputSchema(setCoachVisibilitySchema)
+  .action(async ({ parsedInput }) => {
+    const coach = await setCoachVisibility(
+      db,
+      parsedInput.id,
+      parsedInput.visibility,
+    );
+
+    revalidatePath("/coaches");
+    revalidatePath(`/coaches/${parsedInput.id}`);
+
+    return { ok: true as const, coach };
+  });

--- a/apps/dashboard/src/actions/coaches/updateCoach.ts
+++ b/apps/dashboard/src/actions/coaches/updateCoach.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { db } from "@/lib/db";
+import { staffActionClient } from "@/lib/safe-action";
+import { updateCoachSchema } from "@/lib/validation/coaches";
+import { updateCoach } from "@/utils/coaches";
+
+export const updateCoachAction = staffActionClient
+  .metadata({ actionName: "updateCoach" })
+  .inputSchema(updateCoachSchema)
+  .action(async ({ parsedInput }) => {
+    const { id, ...patch } = parsedInput;
+    const coach = await updateCoach(db, id, patch);
+
+    revalidatePath("/coaches");
+    revalidatePath(`/coaches/${id}`);
+
+    return { ok: true as const, coach };
+  });

--- a/apps/dashboard/src/app/(dashboard)/coaches/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/coaches/[id]/page.tsx
@@ -1,0 +1,55 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeftIcon } from "@phosphor-icons/react/dist/ssr";
+
+import { CoachVisibilityCard } from "@/components/coaches/coach-visibility-card";
+import { EditCoachForm } from "@/components/coaches/edit-coach-form";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { db } from "@/lib/db";
+import { coachCompletenessGaps, getCoach } from "@/utils/coaches";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const coach = await getCoach(db, id);
+
+  if (!coach) {
+    notFound();
+  }
+
+  const isPublic = coach.visibility === "public";
+
+  return (
+    <main className="flex h-full w-full flex-col gap-8 p-10">
+      <div className="flex flex-col gap-4">
+        <Button asChild variant="outline" className="w-fit">
+          <Link href="/coaches">
+            <ArrowLeftIcon />
+            Coaches
+          </Link>
+        </Button>
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-2xl font-bold">{coach.name}</h1>
+            <Badge variant={isPublic ? "default" : "secondary"}>
+              {isPublic ? "Public" : "Private"}
+            </Badge>
+          </div>
+          <p className="text-muted-foreground text-sm">Coach profile</p>
+        </div>
+      </div>
+
+      <div className="flex w-full flex-col gap-6">
+        <EditCoachForm coach={coach} />
+        <CoachVisibilityCard
+          coach={coach}
+          gaps={coachCompletenessGaps(coach)}
+        />
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/coaches/error.tsx
+++ b/apps/dashboard/src/app/(dashboard)/coaches/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { StrategyIcon } from "@phosphor-icons/react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+export default function Error({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="flex h-full w-full flex-col gap-10 p-10">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-bold">Coaches</h1>
+      </div>
+
+      <div className="bg-background rounded-lg border border-border p-4 dark:border-input dark:bg-input/30">
+        <Empty className="min-h-56">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <StrategyIcon />
+            </EmptyMedia>
+            <EmptyTitle>Could not load coaches</EmptyTitle>
+            <EmptyDescription>
+              Something went wrong while loading coaches. Try again in a
+              moment.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button type="button" onClick={reset}>
+              Try again
+            </Button>
+          </EmptyContent>
+        </Empty>
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/coaches/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/coaches/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="flex h-full w-full flex-col gap-10 p-10">
+      <Skeleton className="h-8 w-40" />
+
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-36 shrink-0" />
+      </div>
+
+      <div className="bg-background flex h-full w-full flex-col gap-4 rounded-lg border border-border p-4 dark:border-input dark:bg-input/30">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <Skeleton key={index} className="h-16 w-full rounded-lg" />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/coaches/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/coaches/page.tsx
@@ -1,0 +1,102 @@
+import { Suspense } from "react";
+import Link from "next/link";
+import { StrategyIcon } from "@phosphor-icons/react/ssr";
+import { and, asc, eq, ilike, isNull } from "drizzle-orm";
+import { schema } from "@dtm/database";
+
+import { CreateCoachDialog } from "@/components/coaches/create-coach-dialog";
+import SearchBar from "@/components/players/search-bar";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemTitle,
+} from "@/components/ui/item";
+import { db } from "@/lib/db";
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>;
+}) {
+  const sp = await searchParams;
+  const q = typeof sp.q === "string" ? sp.q.trim() : "";
+
+  const coaches = await db
+    .select({
+      id: schema.clients.id,
+      name: schema.clients.name,
+      nationality: schema.clients.nationality,
+      lastClub: schema.clients.lastClub,
+      visibility: schema.clients.visibility,
+    })
+    .from(schema.clients)
+    .where(
+      and(
+        eq(schema.clients.kind, "coach"),
+        isNull(schema.clients.trashedAt),
+        q ? ilike(schema.clients.name, `%${q}%`) : undefined,
+      ),
+    )
+    .orderBy(asc(schema.clients.name));
+
+  return (
+    <main className="flex h-full w-full flex-col gap-10 p-10">
+      <h1 className="text-2xl font-bold">Coaches</h1>
+
+      <div className="flex items-center gap-2">
+        <Suspense>
+          <SearchBar placeholder="Search coaches by name..." />
+        </Suspense>
+        <CreateCoachDialog />
+      </div>
+
+      <ItemGroup className="bg-background flex h-full w-full flex-col gap-4 rounded-lg border border-border p-4 dark:border-input dark:bg-input/30">
+        {coaches.length === 0 ? (
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <StrategyIcon />
+              </EmptyMedia>
+              <EmptyTitle>No coaches found</EmptyTitle>
+              <EmptyDescription>
+                Get started by creating a new coach with the &quot;New
+                coach&quot; button.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          coaches.map((coach) => (
+            <Item key={coach.id} variant="muted" asChild>
+              <Link
+                href={`/coaches/${coach.id}`}
+                className="flex w-full items-start justify-between gap-4"
+              >
+                <ItemContent>
+                  <ItemTitle>{coach.name}</ItemTitle>
+                  <ItemDescription>
+                    {[
+                      coach.nationality,
+                      coach.lastClub,
+                      coach.visibility === "public" ? "Public" : "Private",
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </ItemDescription>
+                </ItemContent>
+              </Link>
+            </Item>
+          ))
+        )}
+      </ItemGroup>
+    </main>
+  );
+}

--- a/apps/dashboard/src/components/coaches/coach-visibility-card.tsx
+++ b/apps/dashboard/src/components/coaches/coach-visibility-card.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useAction } from "next-safe-action/hooks";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { setCoachVisibilityAction } from "@/actions/coaches/setCoachVisibility";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import type { Coach } from "@/types/coach";
+
+export function CoachVisibilityCard({
+  coach,
+  gaps,
+}: {
+  coach: Coach;
+  gaps: string[];
+}) {
+  const router = useRouter();
+  const isPublic = coach.visibility === "public";
+  const nextVisibility = isPublic ? "private" : "public";
+
+  const { executeAsync, isExecuting } = useAction(setCoachVisibilityAction, {
+    onSuccess: () => {
+      toast.success(
+        isPublic ? "Coach is now private." : "Coach is now public.",
+      );
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      if (error.serverError) {
+        toast.error(error.serverError.message);
+      }
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader className="border-b">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <CardTitle>Visibility</CardTitle>
+          <Badge variant={isPublic ? "default" : "secondary"}>
+            {isPublic ? "Public" : "Private"}
+          </Badge>
+        </div>
+        <CardDescription>
+          Public means this Coach is on the Roster. Private means not on the
+          Roster. A Coach may be public only when the profile is complete.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4 py-6">
+        {gaps.length > 0 ? (
+          <div className="rounded-md border border-border bg-muted/40 px-4 py-3">
+            <p className="text-sm font-medium">Incomplete for the Roster</p>
+            <ul className="text-muted-foreground mt-3 list-disc space-y-1 pl-4 text-sm">
+              {gaps.map((gap) => (
+                <li key={gap}>{gap}</li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            This profile is complete. It can be public.
+          </p>
+        )}
+      </CardContent>
+      <CardFooter className="justify-end border-t py-4">
+        <Button
+          type="button"
+          disabled={isExecuting || (!isPublic && gaps.length > 0)}
+          onClick={() => {
+            void executeAsync({ id: coach.id, visibility: nextVisibility });
+          }}
+        >
+          {isExecuting ? (
+            <Spinner />
+          ) : isPublic ? (
+            "Make private"
+          ) : (
+            "Make public"
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/coaches/create-coach-dialog.tsx
+++ b/apps/dashboard/src/components/coaches/create-coach-dialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { FormProvider, useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useAction } from "next-safe-action/hooks";
+import { toast } from "sonner";
+import type { z } from "zod";
+
+import { PlusIcon } from "@phosphor-icons/react/dist/ssr";
+
+import { createCoachAction } from "@/actions/coaches/createCoach";
+import SubmitButton from "@/components/form/submit-button";
+import TextField from "@/components/form/text-field";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { FieldGroup } from "@/components/ui/field";
+import { createCoachSchema } from "@/lib/validation/coaches";
+
+type FormValues = {
+  name: string;
+  nationality: string;
+  lastClub: string;
+};
+
+export function CreateCoachDialog() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+
+  const methods = useForm<FormValues, unknown, z.output<typeof createCoachSchema>>({
+    resolver: zodResolver(createCoachSchema) as Resolver<
+      FormValues,
+      unknown,
+      z.output<typeof createCoachSchema>
+    >,
+    defaultValues: {
+      name: "",
+      nationality: "",
+      lastClub: "",
+    },
+  });
+
+  const { executeAsync, isExecuting } = useAction(createCoachAction, {
+    onSuccess: () => {
+      toast.success("Coach created successfully.");
+      methods.reset();
+      setOpen(false);
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      if (error.serverError) {
+        toast.error(error.serverError.message);
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (!open) {
+      methods.reset();
+    }
+  }, [open, methods]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <PlusIcon />
+          New coach
+        </Button>
+      </DialogTrigger>
+      <DialogContent showCloseButton={!isExecuting}>
+        <DialogHeader>
+          <DialogTitle>New coach</DialogTitle>
+          <DialogDescription>
+            A Coach starts private. Public requires name, nationality, last
+            club, and a Eurobasket link.
+          </DialogDescription>
+        </DialogHeader>
+        <FormProvider {...methods}>
+          <form
+            onSubmit={methods.handleSubmit((values) => executeAsync(values))}
+            className="flex flex-col gap-4"
+            noValidate
+          >
+            <FieldGroup>
+              <TextField
+                name="name"
+                label="Name"
+                placeholder="Pat Riley"
+                disabled={isExecuting}
+              />
+              <TextField
+                name="nationality"
+                label="Nationality"
+                placeholder="USA"
+                disabled={isExecuting}
+              />
+              <TextField
+                name="lastClub"
+                label="Last club"
+                placeholder="Miami Heat"
+                disabled={isExecuting}
+              />
+            </FieldGroup>
+            <DialogFooter className="gap-2 border-t pt-4 sm:justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-1 sm:flex-initial"
+                disabled={isExecuting}
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <div className="flex-1 sm:flex-initial">
+                <SubmitButton label="Create coach" isExecuting={isExecuting} />
+              </div>
+            </DialogFooter>
+          </form>
+        </FormProvider>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/components/coaches/edit-coach-form.tsx
+++ b/apps/dashboard/src/components/coaches/edit-coach-form.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { FormProvider, useForm, type Resolver } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useAction } from "next-safe-action/hooks";
+import { toast } from "sonner";
+import type { z } from "zod";
+
+import { updateCoachAction } from "@/actions/coaches/updateCoach";
+import TextField from "@/components/form/text-field";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { FieldGroup } from "@/components/ui/field";
+import { Spinner } from "@/components/ui/spinner";
+import { updateCoachSchema } from "@/lib/validation/coaches";
+import type { Coach } from "@/types/coach";
+
+type FormValues = {
+  id: string;
+  name: string;
+  nationality: string;
+  lastClub: string;
+  eurobasketLink: string;
+};
+
+export function EditCoachForm({ coach }: { coach: Coach }) {
+  const router = useRouter();
+
+  const methods = useForm<FormValues, unknown, z.output<typeof updateCoachSchema>>({
+    resolver: zodResolver(updateCoachSchema) as Resolver<
+      FormValues,
+      unknown,
+      z.output<typeof updateCoachSchema>
+    >,
+    defaultValues: {
+      id: coach.id,
+      name: coach.name,
+      nationality: coach.nationality,
+      lastClub: coach.lastClub,
+      eurobasketLink: coach.eurobasketLink ?? "",
+    },
+  });
+
+  const { executeAsync, isExecuting } = useAction(updateCoachAction, {
+    onSuccess: () => {
+      toast.success("Coach updated successfully.");
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      if (error.serverError) {
+        toast.error(error.serverError.message);
+      }
+    },
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle>Profile</CardTitle>
+          <CardDescription>
+            A public Coach needs name, nationality, last club, and a Eurobasket
+            link. Height, Category, and media are Player facts.
+          </CardDescription>
+        </CardHeader>
+        <form
+          onSubmit={methods.handleSubmit((values) => executeAsync(values))}
+          noValidate
+        >
+          <CardContent className="pb-6">
+            <FieldGroup className="gap-6">
+              <input type="hidden" {...methods.register("id")} />
+              <TextField
+                name="name"
+                label="Name"
+                placeholder="Pat Riley"
+                disabled={isExecuting}
+              />
+              <TextField
+                name="nationality"
+                label="Nationality"
+                placeholder="USA"
+                disabled={isExecuting}
+              />
+              <TextField
+                name="lastClub"
+                label="Last club"
+                placeholder="Miami Heat"
+                disabled={isExecuting}
+              />
+              <TextField
+                name="eurobasketLink"
+                label="Eurobasket link"
+                placeholder="https://basketball.eurobasket.com/..."
+                disabled={isExecuting}
+              />
+            </FieldGroup>
+          </CardContent>
+          <CardFooter className="justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isExecuting}
+              onClick={() => methods.reset()}
+            >
+              Reset
+            </Button>
+            <Button type="submit" disabled={isExecuting}>
+              {isExecuting ? <Spinner /> : "Save profile"}
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </FormProvider>
+  );
+}

--- a/apps/dashboard/src/components/sidebar/app-sidebar.tsx
+++ b/apps/dashboard/src/components/sidebar/app-sidebar.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {
   EnvelopeSimpleIcon,
   FolderIcon,
+  StrategyIcon,
   UserGearIcon,
   UsersIcon,
 } from "@phosphor-icons/react";
@@ -26,11 +27,16 @@ const contactsItems: MenuItem[] = [
   },
 ];
 
-const playersItems: MenuItem[] = [
+const clientItems: MenuItem[] = [
   {
     title: "Players",
     url: "/players",
     icon: UsersIcon,
+  },
+  {
+    title: "Coaches",
+    url: "/coaches",
+    icon: StrategyIcon,
   },
   {
     title: "Categories",
@@ -64,7 +70,7 @@ export function AppSidebar({
       </SidebarHeader>
       <SidebarContent>
         <NavGroup label="Inbox" items={contactsItems} />
-        <NavGroup label="Players Content" items={playersItems} />
+        <NavGroup label="Clients" items={clientItems} />
         {isOwner ? (
           <NavGroup label="Administration" items={usersItems} />
         ) : null}

--- a/apps/dashboard/src/components/sidebar/site-header.tsx
+++ b/apps/dashboard/src/components/sidebar/site-header.tsx
@@ -14,6 +14,7 @@ import {
 const routeLabels: Array<{ prefix: string; label: string }> = [
   { prefix: "/contacts", label: "Contacts" },
   { prefix: "/players", label: "Players" },
+  { prefix: "/coaches", label: "Coaches" },
   { prefix: "/categories", label: "Categories" },
   { prefix: "/users", label: "Users" },
 ];

--- a/apps/dashboard/src/lib/validation/coaches.test.ts
+++ b/apps/dashboard/src/lib/validation/coaches.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createCoachSchema,
+  setCoachVisibilitySchema,
+  updateCoachSchema,
+} from "./coaches";
+
+test("create Coach accepts name, nationality, and last club", () => {
+  const parsed = createCoachSchema.safeParse({
+    name: "Pat Riley",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+  });
+
+  assert.equal(parsed.success, true);
+});
+
+test("create Coach trims text", () => {
+  const parsed = createCoachSchema.safeParse({
+    name: "  Pat Riley  ",
+    nationality: "  USA  ",
+    lastClub: "  Miami Heat  ",
+  });
+
+  assert.equal(parsed.success, true);
+  if (parsed.success) {
+    assert.equal(parsed.data.name, "Pat Riley");
+    assert.equal(parsed.data.nationality, "USA");
+    assert.equal(parsed.data.lastClub, "Miami Heat");
+  }
+});
+
+test("create Coach rejects a name that is only spaces", () => {
+  const parsed = createCoachSchema.safeParse({
+    name: "   ",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+  });
+
+  assert.equal(parsed.success, false);
+});
+
+test("create Coach ignores Player facts", () => {
+  const parsed = createCoachSchema.safeParse({
+    name: "Pat Riley",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+    heightCm: 185,
+    categoryId: "00000000-0000-4000-8000-000000000001",
+  });
+
+  assert.equal(parsed.success, true);
+  if (parsed.success) {
+    assert.equal("heightCm" in parsed.data, false);
+    assert.equal("categoryId" in parsed.data, false);
+  }
+});
+
+test("update Coach treats an empty Eurobasket URL as absent", () => {
+  const parsed = updateCoachSchema.safeParse({
+    id: "00000000-0000-4000-8000-000000000001",
+    name: "Pat Riley",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+    eurobasketLink: "",
+  });
+
+  assert.equal(parsed.success, true);
+  if (parsed.success) {
+    assert.equal(parsed.data.eurobasketLink, null);
+  }
+});
+
+test("update Coach accepts a Eurobasket URL", () => {
+  const parsed = updateCoachSchema.safeParse({
+    id: "00000000-0000-4000-8000-000000000001",
+    name: "Pat Riley",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+    eurobasketLink: "https://basketball.eurobasket.com/coach/Pat-Riley/1",
+  });
+
+  assert.equal(parsed.success, true);
+  if (parsed.success) {
+    assert.equal(
+      parsed.data.eurobasketLink,
+      "https://basketball.eurobasket.com/coach/Pat-Riley/1",
+    );
+  }
+});
+
+test("Visibility is public or private", () => {
+  const parsed = setCoachVisibilitySchema.safeParse({
+    id: "00000000-0000-4000-8000-000000000001",
+    visibility: "public",
+  });
+  assert.equal(parsed.success, true);
+
+  const draft = setCoachVisibilitySchema.safeParse({
+    id: "00000000-0000-4000-8000-000000000001",
+    visibility: "draft",
+  });
+  assert.equal(draft.success, false);
+});

--- a/apps/dashboard/src/lib/validation/coaches.ts
+++ b/apps/dashboard/src/lib/validation/coaches.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+const requiredText = z.string().trim().min(1);
+
+const optionalUrl = z.preprocess(
+  (value) => (value === "" || value === undefined ? null : value),
+  z.url().nullable(),
+);
+
+export const createCoachSchema = z.object({
+  name: requiredText,
+  nationality: requiredText,
+  lastClub: requiredText,
+});
+
+export const updateCoachSchema = z.object({
+  id: z.uuid(),
+  name: requiredText,
+  nationality: requiredText,
+  lastClub: requiredText,
+  eurobasketLink: optionalUrl,
+});
+
+export const setCoachVisibilitySchema = z.object({
+  id: z.uuid(),
+  visibility: z.enum(["public", "private"]),
+});

--- a/apps/dashboard/src/types/coach.ts
+++ b/apps/dashboard/src/types/coach.ts
@@ -1,0 +1,10 @@
+export type CoachVisibility = "public" | "private";
+
+export type Coach = {
+  id: string;
+  name: string;
+  nationality: string;
+  lastClub: string;
+  eurobasketLink: string | null;
+  visibility: CoachVisibility;
+};

--- a/apps/dashboard/src/utils/coaches.test.ts
+++ b/apps/dashboard/src/utils/coaches.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { before, beforeEach, test } from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { sql } from "drizzle-orm";
+import { createDatabase } from "@dtm/database";
+
+import { ConflictError, NotFoundError } from "./errors";
+import {
+  createCoach,
+  getCoach,
+  setCoachVisibility,
+  updateCoach,
+} from "./coaches";
+import { addPlayerVideo, createPlayer, getPlayer } from "./players";
+
+const root = path.resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "../../../../",
+);
+process.loadEnvFile(path.join(root, ".env"));
+
+const connectionString = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error("DATABASE_URL or TEST_DATABASE_URL is required");
+}
+
+const db = createDatabase(connectionString);
+
+before(async () => {
+  await db.execute(sql`select 1`);
+});
+
+beforeEach(async () => {
+  await db.execute(
+    sql`truncate table player_gallery_images, player_videos, clients, categories restart identity cascade`,
+  );
+});
+
+function coachInput() {
+  return {
+    name: "Pat Riley",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+  };
+}
+
+function eurobasketLink() {
+  return "https://basketball.eurobasket.com/coach/Pat-Riley/1";
+}
+
+async function completeCoach() {
+  return createCoach(db, {
+    ...coachInput(),
+    eurobasketLink: eurobasketLink(),
+  });
+}
+
+test("create Coach makes a private Client retrievable by the returned id", async () => {
+  const created = await createCoach(db, coachInput());
+  const retrieved = await getCoach(db, created.id);
+
+  assert.equal(created.name, "Pat Riley");
+  assert.equal(created.visibility, "private");
+  assert.equal(created.eurobasketLink, null);
+  assert.equal(retrieved?.id, created.id);
+  assert.equal(retrieved?.name, "Pat Riley");
+  assert.equal(retrieved?.visibility, "private");
+});
+
+test("a Player and a Coach can exist as two Clients", async () => {
+  const player = await createPlayer(db, {
+    name: "Pat Riley",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+  });
+  const coach = await createCoach(db, coachInput());
+
+  assert.notEqual(player.id, coach.id);
+  assert.equal(await getPlayer(db, coach.id), null);
+  assert.equal(await getCoach(db, player.id), null);
+  assert.equal((await getPlayer(db, player.id))?.name, "Pat Riley");
+  assert.equal((await getCoach(db, coach.id))?.name, "Pat Riley");
+});
+
+test("Player media cannot be stored on a Coach", async () => {
+  const coach = await createCoach(db, coachInput());
+
+  await assert.rejects(
+    () =>
+      addPlayerVideo(
+        db,
+        coach.id,
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ),
+    (error: unknown) =>
+      error instanceof NotFoundError && error.message === "Player not found",
+  );
+});
+
+test("a Coach cannot be public unless the profile is complete", async () => {
+  const created = await createCoach(db, coachInput());
+
+  await assert.rejects(
+    () => setCoachVisibility(db, created.id, "public"),
+    (error: unknown) =>
+      error instanceof ConflictError &&
+      error.message ===
+        "A Coach cannot be public unless the profile is complete.",
+  );
+
+  assert.equal((await getCoach(db, created.id))?.visibility, "private");
+});
+
+test("a complete Coach can be public", async () => {
+  const created = await completeCoach();
+
+  const updated = await setCoachVisibility(db, created.id, "public");
+
+  assert.equal(updated.visibility, "public");
+  assert.equal(updated.eurobasketLink, eurobasketLink());
+  assert.equal((await getCoach(db, created.id))?.visibility, "public");
+});
+
+test("a public Coach can be made private", async () => {
+  const created = await completeCoach();
+  await setCoachVisibility(db, created.id, "public");
+
+  const updated = await setCoachVisibility(db, created.id, "private");
+
+  assert.equal(updated.visibility, "private");
+  assert.equal((await getCoach(db, created.id))?.visibility, "private");
+});
+
+test("editing a public Coach refuses an incomplete profile", async () => {
+  const created = await completeCoach();
+  await setCoachVisibility(db, created.id, "public");
+
+  await assert.rejects(
+    () => updateCoach(db, created.id, { eurobasketLink: null }),
+    (error: unknown) =>
+      error instanceof ConflictError &&
+      error.message ===
+        "A Coach cannot be public unless the profile is complete.",
+  );
+
+  assert.equal((await getCoach(db, created.id))?.eurobasketLink, eurobasketLink());
+});
+
+test("get Coach returns null for an id that does not exist", async () => {
+  assert.equal(
+    await getCoach(db, "00000000-0000-0000-0000-000000000000"),
+    null,
+  );
+});
+
+test("update Coach rejects an id that does not exist", async () => {
+  await assert.rejects(
+    () =>
+      updateCoach(db, "00000000-0000-0000-0000-000000000000", {
+        name: "Pat Riley",
+      }),
+    (error: unknown) =>
+      error instanceof NotFoundError && error.message === "Coach not found",
+  );
+});

--- a/apps/dashboard/src/utils/coaches.ts
+++ b/apps/dashboard/src/utils/coaches.ts
@@ -1,0 +1,166 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { schema, type Database } from "@dtm/database";
+
+import type { Coach, CoachVisibility } from "@/types/coach";
+import { ConflictError, NotFoundError } from "@/utils/errors";
+
+export type CoachWrite = {
+  name: string;
+  nationality: string;
+  lastClub: string;
+  eurobasketLink?: string | null;
+};
+
+export type CoachPatch = Partial<CoachWrite>;
+
+export function coachCompletenessGaps(coach: {
+  name: string;
+  nationality: string;
+  lastClub: string;
+  eurobasketLink: string | null;
+}): string[] {
+  const gaps: string[] = [];
+
+  if (!coach.name.trim()) {
+    gaps.push("Name");
+  }
+  if (!coach.nationality.trim()) {
+    gaps.push("Nationality");
+  }
+  if (!coach.lastClub.trim()) {
+    gaps.push("Last club");
+  }
+  if (!coach.eurobasketLink) {
+    gaps.push("Eurobasket link");
+  }
+
+  return gaps;
+}
+
+function isCoachComplete(coach: {
+  name: string;
+  nationality: string;
+  lastClub: string;
+  eurobasketLink: string | null;
+}): boolean {
+  return coachCompletenessGaps(coach).length === 0;
+}
+
+export async function getCoach(db: Database, id: string): Promise<Coach | null> {
+  const [row] = await db
+    .select({
+      id: schema.clients.id,
+      name: schema.clients.name,
+      nationality: schema.clients.nationality,
+      lastClub: schema.clients.lastClub,
+      eurobasketLink: schema.clients.eurobasketLink,
+      visibility: schema.clients.visibility,
+    })
+    .from(schema.clients)
+    .where(
+      and(
+        eq(schema.clients.id, id),
+        eq(schema.clients.kind, "coach"),
+        isNull(schema.clients.trashedAt),
+      ),
+    )
+    .limit(1);
+
+  return row ?? null;
+}
+
+export async function createCoach(
+  db: Database,
+  input: CoachWrite,
+): Promise<Coach> {
+  const [row] = await db
+    .insert(schema.clients)
+    .values({
+      kind: "coach",
+      name: input.name,
+      nationality: input.nationality,
+      lastClub: input.lastClub,
+      visibility: "private",
+      eurobasketLink: input.eurobasketLink ?? null,
+    })
+    .returning({ id: schema.clients.id });
+
+  if (!row) {
+    throw new Error("createCoach returned no row");
+  }
+
+  const coach = await getCoach(db, row.id);
+  if (!coach) {
+    throw new Error("createCoach could not load coach");
+  }
+
+  return coach;
+}
+
+export async function updateCoach(
+  db: Database,
+  id: string,
+  patch: CoachPatch,
+): Promise<Coach> {
+  const existing = await getCoach(db, id);
+  if (!existing) {
+    throw new NotFoundError("Coach");
+  }
+
+  const next = {
+    name: patch.name ?? existing.name,
+    nationality: patch.nationality ?? existing.nationality,
+    lastClub: patch.lastClub ?? existing.lastClub,
+    eurobasketLink:
+      patch.eurobasketLink === undefined
+        ? existing.eurobasketLink
+        : patch.eurobasketLink,
+  };
+
+  if (existing.visibility === "public" && !isCoachComplete(next)) {
+    throw new ConflictError(
+      "A Coach cannot be public unless the profile is complete.",
+    );
+  }
+
+  await db
+    .update(schema.clients)
+    .set({ ...next, updatedAt: new Date() })
+    .where(eq(schema.clients.id, id));
+
+  const coach = await getCoach(db, id);
+  if (!coach) {
+    throw new NotFoundError("Coach");
+  }
+
+  return coach;
+}
+
+export async function setCoachVisibility(
+  db: Database,
+  id: string,
+  visibility: CoachVisibility,
+): Promise<Coach> {
+  const existing = await getCoach(db, id);
+  if (!existing) {
+    throw new NotFoundError("Coach");
+  }
+
+  if (visibility === "public" && !isCoachComplete(existing)) {
+    throw new ConflictError(
+      "A Coach cannot be public unless the profile is complete.",
+    );
+  }
+
+  await db
+    .update(schema.clients)
+    .set({ visibility, updatedAt: new Date() })
+    .where(eq(schema.clients.id, id));
+
+  const coach = await getCoach(db, id);
+  if (!coach) {
+    throw new NotFoundError("Coach");
+  }
+
+  return coach;
+}


### PR DESCRIPTION
## Summary
- Staff can list, create, and edit Coaches as Clients of kind Coach on Neon through next-safe-action and Drizzle
- A Coach has name, nationality, last club, and Eurobasket link; height, Category, and media stay Player facts
- Visibility is public or private; a Coach may be public only when that profile (including Eurobasket) is complete

Closes #7

## Test plan
- [x] Domain tests: two Clients, no Player media on a Coach, completeness, Visibility
- [x] Zod validation tests for Coach schemas
- [x] Coach tests passed (16)


Made with [Cursor](https://cursor.com)