### PR TITLE
Let the landing site show the Roster from Neon

### DIFF
--- a/.cursor/rules/drizzle.mdc
+++ b/.cursor/rules/drizzle.mdc
@@ -1,0 +1,30 @@
+---
+description: Drizzle 0.44 — declare relations(); read with findFirst/findMany
+alwaysApply: true
+---
+
+# Drizzle
+
+We are on drizzle-orm 0.44. Use `import { relations } from "drizzle-orm"` with `one()` / `many()`. Do not copy `defineRelations` from current orm.drizzle.team docs (that is 1.0 RC).
+
+Foreign keys stay on the tables. Every FK also gets a `relations()` export in `packages/database/src/db/schema.ts` (both sides — v1 needs the `one()` for a `many()`). `createDatabase` already passes `{ schema }`. ContactRequest has no FK. Roster views are not tables. Do not invent relations for those.
+
+## Reads
+
+`db.query.<table>.findFirst` (one row) or `findMany` (many). Load related rows with `with`. Use `columns` when the caller does not need the full row.
+
+```ts
+// ✅
+const player = await db.query.clients.findFirst({
+  where: and(eq(schema.clients.id, id), eq(schema.clients.kind, "player")),
+  with: { category: true, videos: true },
+});
+
+// ❌ select + leftJoin + extra query for videos
+```
+
+Search and filters stay in `where` (`ilike`, `inArray`). That is not a reason to join.
+
+## Query builder
+
+`insert` / `update` / `delete` / `.returning()`. Aggregations (`count`, `groupBy`) — e.g. Category player counts. Landing Roster views (`roster`, `roster_gallery_images`, `roster_videos`) — the landing role cannot `SELECT` `clients` (ADR 0005).

--- a/.cursor/rules/nextjs-page-structure.mdc
+++ b/.cursor/rules/nextjs-page-structure.mdc
@@ -38,9 +38,13 @@ export default function Page({ searchParams }: Props) {
 ```tsx
 // ✅ GOOD — Drizzle read and small HTML in Page; client dialog stays extracted
 export default async function Page() {
-  const players = await db
-    .select({ id: schema.clients.id, name: schema.clients.name })
-    .from(schema.clients);
+  const players = await db.query.clients.findMany({
+    columns: { id: true, name: true },
+    where: and(
+      eq(schema.clients.kind, "player"),
+      isNull(schema.clients.trashedAt),
+    ),
+  });
 
   return (
     <main>

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,10 @@ NEXT_PUBLIC_INSFORGE_ANON_KEY=
 
 # Neon Postgres — owned by `@dtm/database` (`packages/database/src/config/env.ts`).
 # Required by dashboard, landing, and `pnpm db:push` / tests.
-# One connection for local work. Do not add a second Neon role here.
+# Local: one owner connection. Production landing uses Neon role `dtm_landing`
+# (SELECT roster views, INSERT contact_requests). Create that role in Neon, set
+# the landing project's DATABASE_URL to its connection string, then run
+# `pnpm --filter @dtm/database db:grant-landing` as the owner.
 DATABASE_URL=postgresql://user:password@host/neondb?sslmode=require
 
 # Dashboard only

--- a/apps/dashboard/src/actions/users/deleteUser.ts
+++ b/apps/dashboard/src/actions/users/deleteUser.ts
@@ -19,14 +19,13 @@ export const deleteUserAction = ownerActionClient
   .metadata({ actionName: "deleteUser" })
   .inputSchema(deleteUserSchema)
   .action(async ({ parsedInput, ctx }) => {
-    const [target] = await db
-      .select({
-        id: schema.user.id,
-        role: schema.user.role,
-      })
-      .from(schema.user)
-      .where(eq(schema.user.id, parsedInput.id))
-      .limit(1);
+    const target = await db.query.user.findFirst({
+      columns: {
+        id: true,
+        role: true,
+      },
+      where: eq(schema.user.id, parsedInput.id),
+    });
 
     const targetRole = toDashboardRole(target?.role);
     if (!target || !targetRole) {

--- a/apps/dashboard/src/actions/users/setUserName.ts
+++ b/apps/dashboard/src/actions/users/setUserName.ts
@@ -15,11 +15,10 @@ export const setUserNameAction = ownerActionClient
   .metadata({ actionName: "setUserName" })
   .inputSchema(setUserNameSchema)
   .action(async ({ parsedInput }) => {
-    const [target] = await db
-      .select({ id: schema.user.id })
-      .from(schema.user)
-      .where(eq(schema.user.id, parsedInput.userId))
-      .limit(1);
+    const target = await db.query.user.findFirst({
+      columns: { id: true },
+      where: eq(schema.user.id, parsedInput.userId),
+    });
 
     if (!target) {
       throw new NotFoundError("User");

--- a/apps/dashboard/src/actions/users/setUserRole.ts
+++ b/apps/dashboard/src/actions/users/setUserRole.ts
@@ -19,14 +19,13 @@ export const setUserRoleAction = ownerActionClient
   .metadata({ actionName: "setUserRole" })
   .inputSchema(setUserRoleSchema)
   .action(async ({ parsedInput, ctx }) => {
-    const [target] = await db
-      .select({
-        id: schema.user.id,
-        role: schema.user.role,
-      })
-      .from(schema.user)
-      .where(eq(schema.user.id, parsedInput.userId))
-      .limit(1);
+    const target = await db.query.user.findFirst({
+      columns: {
+        id: true,
+        role: true,
+      },
+      where: eq(schema.user.id, parsedInput.userId),
+    });
 
     const targetRole = toDashboardRole(target?.role);
     if (!target || !targetRole) {

--- a/apps/dashboard/src/app/(dashboard)/categories/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/categories/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { and, asc, eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { schema } from "@dtm/database";
 import { ArrowLeftIcon } from "@phosphor-icons/react/dist/ssr";
 
@@ -17,34 +17,30 @@ export default async function Page({
 }) {
   const { id } = await params;
 
-  const [[category], players] = await Promise.all([
-    db
-      .select({
-        id: schema.categories.id,
-        name: schema.categories.name,
-      })
-      .from(schema.categories)
-      .where(eq(schema.categories.id, id))
-      .limit(1),
-    db
-      .select({
-        id: schema.clients.id,
-        name: schema.clients.name,
-        lastClub: schema.clients.lastClub,
-      })
-      .from(schema.clients)
-      .where(
-        and(
-          eq(schema.clients.categoryId, id),
-          eq(schema.clients.kind, "player"),
-        ),
-      )
-      .orderBy(asc(schema.clients.name)),
-  ]);
+  const category = await db.query.categories.findFirst({
+    columns: {
+      id: true,
+      name: true,
+    },
+    where: eq(schema.categories.id, id),
+    with: {
+      players: {
+        columns: {
+          id: true,
+          name: true,
+          lastClub: true,
+        },
+        where: eq(schema.clients.kind, "player"),
+        orderBy: [asc(schema.clients.name)],
+      },
+    },
+  });
 
   if (!category) {
     notFound();
   }
+
+  const players = category.players;
 
   return (
     <main className="flex h-full w-full flex-col gap-8 p-10">

--- a/apps/dashboard/src/app/(dashboard)/coaches/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/coaches/page.tsx
@@ -30,23 +30,21 @@ export default async function Page({
   const sp = await searchParams;
   const q = typeof sp.q === "string" ? sp.q.trim() : "";
 
-  const coaches = await db
-    .select({
-      id: schema.clients.id,
-      name: schema.clients.name,
-      nationality: schema.clients.nationality,
-      lastClub: schema.clients.lastClub,
-      visibility: schema.clients.visibility,
-    })
-    .from(schema.clients)
-    .where(
-      and(
-        eq(schema.clients.kind, "coach"),
-        isNull(schema.clients.trashedAt),
-        q ? ilike(schema.clients.name, `%${q}%`) : undefined,
-      ),
-    )
-    .orderBy(asc(schema.clients.name));
+  const coaches = await db.query.clients.findMany({
+    columns: {
+      id: true,
+      name: true,
+      nationality: true,
+      lastClub: true,
+      visibility: true,
+    },
+    where: and(
+      eq(schema.clients.kind, "coach"),
+      isNull(schema.clients.trashedAt),
+      q ? ilike(schema.clients.name, `%${q}%`) : undefined,
+    ),
+    orderBy: [asc(schema.clients.name)],
+  });
 
   return (
     <main className="flex h-full w-full flex-col gap-10 p-10">

--- a/apps/dashboard/src/app/(dashboard)/contacts/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/contacts/page.tsx
@@ -6,18 +6,18 @@ import { ContactsInbox } from "@/components/contacts/contacts-inbox";
 import { db } from "@/lib/db";
 
 export default async function Page() {
-  const requests = await db
-    .select({
-      id: schema.contactRequests.id,
-      reason: schema.contactRequests.reason,
-      email: schema.contactRequests.email,
-      phone: schema.contactRequests.phone,
-      message: schema.contactRequests.message,
-      status: schema.contactRequests.status,
-      createdAt: schema.contactRequests.createdAt,
-    })
-    .from(schema.contactRequests)
-    .orderBy(desc(schema.contactRequests.createdAt));
+  const requests = await db.query.contactRequests.findMany({
+    columns: {
+      id: true,
+      reason: true,
+      email: true,
+      phone: true,
+      message: true,
+      status: true,
+      createdAt: true,
+    },
+    orderBy: [desc(schema.contactRequests.createdAt)],
+  });
 
   return (
     <main className="flex h-full w-full flex-col gap-8 p-6 md:p-10">

--- a/apps/dashboard/src/app/(dashboard)/players/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/players/[id]/page.tsx
@@ -21,13 +21,13 @@ export default async function Page({
 
   const [player, categories] = await Promise.all([
     getPlayer(db, id),
-    db
-      .select({
-        id: schema.categories.id,
-        name: schema.categories.name,
-      })
-      .from(schema.categories)
-      .orderBy(asc(schema.categories.name)),
+    db.query.categories.findMany({
+      columns: {
+        id: true,
+        name: true,
+      },
+      orderBy: [asc(schema.categories.name)],
+    }),
   ]);
 
   if (!player) {

--- a/apps/dashboard/src/app/(dashboard)/players/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/players/page.tsx
@@ -36,39 +36,38 @@ export default async function Page({
   const categoryIds = normalizePlayerCategoryIds(rawC);
 
   const [players, categories] = await Promise.all([
-    db
-      .select({
-        id: schema.clients.id,
-        name: schema.clients.name,
-        nationality: schema.clients.nationality,
-        heightCm: schema.clients.heightCm,
-        visibility: schema.clients.visibility,
-        categoryId: schema.clients.categoryId,
-        categoryName: schema.categories.name,
-      })
-      .from(schema.clients)
-      .leftJoin(
-        schema.categories,
-        eq(schema.clients.categoryId, schema.categories.id),
-      )
-      .where(
-        and(
-          eq(schema.clients.kind, "player"),
-          isNull(schema.clients.trashedAt),
-          q ? ilike(schema.clients.name, `%${q}%`) : undefined,
-          categoryIds.length > 0
-            ? inArray(schema.clients.categoryId, categoryIds)
-            : undefined,
-        ),
-      )
-      .orderBy(asc(schema.clients.name)),
-    db
-      .select({
-        id: schema.categories.id,
-        name: schema.categories.name,
-      })
-      .from(schema.categories)
-      .orderBy(asc(schema.categories.name)),
+    db.query.clients.findMany({
+      columns: {
+        id: true,
+        name: true,
+        nationality: true,
+        heightCm: true,
+        visibility: true,
+      },
+      where: and(
+        eq(schema.clients.kind, "player"),
+        isNull(schema.clients.trashedAt),
+        q ? ilike(schema.clients.name, `%${q}%`) : undefined,
+        categoryIds.length > 0
+          ? inArray(schema.clients.categoryId, categoryIds)
+          : undefined,
+      ),
+      orderBy: [asc(schema.clients.name)],
+      with: {
+        category: {
+          columns: {
+            name: true,
+          },
+        },
+      },
+    }),
+    db.query.categories.findMany({
+      columns: {
+        id: true,
+        name: true,
+      },
+      orderBy: [asc(schema.categories.name)],
+    }),
   ]);
 
   return (
@@ -118,8 +117,8 @@ export default async function Page({
                       .join(" · ")}
                   </ItemDescription>
                 </ItemContent>
-                {player.categoryName ? (
-                  <Badge>{player.categoryName}</Badge>
+                {player.category?.name ? (
+                  <Badge>{player.category.name}</Badge>
                 ) : null}
               </Link>
             </Item>

--- a/apps/dashboard/src/app/(dashboard)/users/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/users/[id]/page.tsx
@@ -28,17 +28,16 @@ export default async function Page({
     redirect("/contacts");
   }
 
-  const [[row], [owners]] = await Promise.all([
-    db
-      .select({
-        id: schema.user.id,
-        name: schema.user.name,
-        email: schema.user.email,
-        role: schema.user.role,
-      })
-      .from(schema.user)
-      .where(eq(schema.user.id, id))
-      .limit(1),
+  const [row, [owners]] = await Promise.all([
+    db.query.user.findFirst({
+      columns: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+      },
+      where: eq(schema.user.id, id),
+    }),
     db
       .select({ ownerCount: count() })
       .from(schema.user)

--- a/apps/dashboard/src/app/(dashboard)/users/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/users/page.tsx
@@ -23,16 +23,16 @@ import { db } from "@/lib/db";
 import { toDashboardRole } from "@/utils/auth/owner";
 
 export default async function Page() {
-  const rows = await db
-    .select({
-      id: schema.user.id,
-      name: schema.user.name,
-      email: schema.user.email,
-      role: schema.user.role,
-    })
-    .from(schema.user)
-    .where(inArray(schema.user.role, ["owner", "staff"]))
-    .orderBy(asc(schema.user.name));
+  const rows = await db.query.user.findMany({
+    columns: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+    },
+    where: inArray(schema.user.role, ["owner", "staff"]),
+    orderBy: [asc(schema.user.name)],
+  });
 
   const users = rows.flatMap((row) => {
     const role = toDashboardRole(row.role);

--- a/apps/dashboard/src/scripts/seed-better-auth-owner.ts
+++ b/apps/dashboard/src/scripts/seed-better-auth-owner.ts
@@ -64,11 +64,10 @@ async function main(): Promise<void> {
     ],
   });
 
-  const [existing] = await db
-    .select({ id: schema.user.id })
-    .from(schema.user)
-    .where(eq(schema.user.email, email))
-    .limit(1);
+  const existing = await db.query.user.findFirst({
+    columns: { id: true },
+    where: eq(schema.user.email, email),
+  });
 
   let userId: string;
 

--- a/apps/dashboard/src/utils/categories.ts
+++ b/apps/dashboard/src/utils/categories.ts
@@ -96,15 +96,14 @@ export async function getCategory(
   db: Database,
   id: string,
 ): Promise<Category | null> {
-  const [row] = await db
-    .select({
-      id: schema.categories.id,
-      name: schema.categories.name,
-      slug: schema.categories.slug,
-    })
-    .from(schema.categories)
-    .where(eq(schema.categories.id, id))
-    .limit(1);
+  const row = await db.query.categories.findFirst({
+    columns: {
+      id: true,
+      name: true,
+      slug: true,
+    },
+    where: eq(schema.categories.id, id),
+  });
 
   return row ?? null;
 }

--- a/apps/dashboard/src/utils/coaches.ts
+++ b/apps/dashboard/src/utils/coaches.ts
@@ -47,24 +47,21 @@ function isCoachComplete(coach: {
 }
 
 export async function getCoach(db: Database, id: string): Promise<Coach | null> {
-  const [row] = await db
-    .select({
-      id: schema.clients.id,
-      name: schema.clients.name,
-      nationality: schema.clients.nationality,
-      lastClub: schema.clients.lastClub,
-      eurobasketLink: schema.clients.eurobasketLink,
-      visibility: schema.clients.visibility,
-    })
-    .from(schema.clients)
-    .where(
-      and(
-        eq(schema.clients.id, id),
-        eq(schema.clients.kind, "coach"),
-        isNull(schema.clients.trashedAt),
-      ),
-    )
-    .limit(1);
+  const row = await db.query.clients.findFirst({
+    columns: {
+      id: true,
+      name: true,
+      nationality: true,
+      lastClub: true,
+      eurobasketLink: true,
+      visibility: true,
+    },
+    where: and(
+      eq(schema.clients.id, id),
+      eq(schema.clients.kind, "coach"),
+      isNull(schema.clients.trashedAt),
+    ),
+  });
 
   return row ?? null;
 }

--- a/apps/dashboard/src/utils/contact-requests.ts
+++ b/apps/dashboard/src/utils/contact-requests.ts
@@ -21,11 +21,18 @@ export async function getContactRequest(
   db: Database,
   id: string,
 ): Promise<ContactRequest | null> {
-  const [row] = await db
-    .select(contactRequestColumns)
-    .from(schema.contactRequests)
-    .where(eq(schema.contactRequests.id, id))
-    .limit(1);
+  const row = await db.query.contactRequests.findFirst({
+    columns: {
+      id: true,
+      reason: true,
+      email: true,
+      phone: true,
+      message: true,
+      status: true,
+      createdAt: true,
+    },
+    where: eq(schema.contactRequests.id, id),
+  });
 
   return row ?? null;
 }

--- a/apps/dashboard/src/utils/players.ts
+++ b/apps/dashboard/src/utils/players.ts
@@ -79,50 +79,52 @@ export async function getPlayer(
   db: Database,
   id: string,
 ): Promise<PlayerDetail | null> {
-  const [row] = await db
-    .select({
-      id: schema.clients.id,
-      name: schema.clients.name,
-      nationality: schema.clients.nationality,
-      lastClub: schema.clients.lastClub,
-      eurobasketLink: schema.clients.eurobasketLink,
-      visibility: schema.clients.visibility,
-      heightCm: schema.clients.heightCm,
-      categoryId: schema.clients.categoryId,
-      categoryName: schema.categories.name,
-      presentationImageUrl: schema.clients.presentationImageUrl,
-    })
-    .from(schema.clients)
-    .leftJoin(
-      schema.categories,
-      eq(schema.clients.categoryId, schema.categories.id),
-    )
-    .where(
-      and(
-        eq(schema.clients.id, id),
-        eq(schema.clients.kind, "player"),
-        isNull(schema.clients.trashedAt),
-      ),
-    )
-    .limit(1);
+  const row = await db.query.clients.findFirst({
+    columns: {
+      id: true,
+      name: true,
+      nationality: true,
+      lastClub: true,
+      eurobasketLink: true,
+      visibility: true,
+      heightCm: true,
+      categoryId: true,
+      presentationImageUrl: true,
+    },
+    where: and(
+      eq(schema.clients.id, id),
+      eq(schema.clients.kind, "player"),
+      isNull(schema.clients.trashedAt),
+    ),
+    with: {
+      category: {
+        columns: {
+          name: true,
+        },
+      },
+      videos: {
+        columns: {
+          id: true,
+          youtubeUrl: true,
+        },
+        orderBy: [
+          asc(schema.playerVideos.sortOrder),
+          asc(schema.playerVideos.createdAt),
+        ],
+      },
+    },
+  });
 
   if (!row) {
     return null;
   }
 
-  const videos = await db
-    .select({
-      id: schema.playerVideos.id,
-      youtubeUrl: schema.playerVideos.youtubeUrl,
-    })
-    .from(schema.playerVideos)
-    .where(eq(schema.playerVideos.clientId, id))
-    .orderBy(
-      asc(schema.playerVideos.sortOrder),
-      asc(schema.playerVideos.createdAt),
-    );
-
-  return { ...row, videos };
+  const { category, videos, ...player } = row;
+  return {
+    ...player,
+    categoryName: category?.name ?? null,
+    videos,
+  };
 }
 
 export async function createPlayer(

--- a/apps/landing/src/lib/roster/queries.ts
+++ b/apps/landing/src/lib/roster/queries.ts
@@ -1,411 +1,79 @@
 import { cache } from "react";
+import {
+  getPublicRosterPlayer as getRosterPlayer,
+  listPublicRosterCategories as listRosterCategories,
+  listPublicRosterPlayers as listRosterPlayers,
+  type ListPublicRosterPlayersParams,
+  type RosterCategory,
+  type RosterPlayer,
+} from "@dtm/database";
 
-import { createInsforgeServer } from "@/lib/insforge-server";
+import { db } from "@/lib/db";
 import type {
   PublicRosterCategory,
-  PublicRosterCategoryRef,
-  PublicRosterGalleryImage,
   PublicRosterPlayer,
-  PublicRosterVideo,
 } from "@/types/roster";
 
-export type ListPublicRosterPlayersParams = {
-  q?: string;
-  categoryIds?: string[];
-};
+export type { ListPublicRosterPlayersParams };
 
-function readPlayerId(row: unknown): string | null {
-  if (typeof row !== "object" || row === null || !("player_id" in row)) {
-    return null;
-  }
-
-  const playerId = (row as { player_id: unknown }).player_id;
-  return typeof playerId === "string" ? playerId : null;
-}
-
-function parseCategoryRefs(value: unknown): PublicRosterCategoryRef[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  const refs: PublicRosterCategoryRef[] = [];
-
-  for (const junction of value) {
-    if (typeof junction !== "object" || junction === null) {
-      continue;
-    }
-
-    const categories = (junction as { categories?: unknown }).categories;
-    if (typeof categories !== "object" || categories === null) {
-      continue;
-    }
-
-    const row = categories as Record<string, unknown>;
-    if (
-      typeof row.id !== "string" ||
-      typeof row.name !== "string" ||
-      typeof row.slug !== "string"
-    ) {
-      continue;
-    }
-
-    refs.push({ id: row.id, name: row.name, slug: row.slug });
-  }
-
-  return refs;
-}
-
-function parseGalleryImages(value: unknown): PublicRosterGalleryImage[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  const images: PublicRosterGalleryImage[] = [];
-
-  for (const item of value) {
-    if (typeof item !== "object" || item === null) {
-      continue;
-    }
-
-    const row = item as Record<string, unknown>;
-    if (
-      typeof row.id !== "string" ||
-      typeof row.url !== "string" ||
-      typeof row.sort_order !== "number"
-    ) {
-      continue;
-    }
-
-    images.push({ id: row.id, url: row.url, sort_order: row.sort_order });
-  }
-
-  return images.sort((a, b) => a.sort_order - b.sort_order);
-}
-
-function parseVideos(value: unknown): PublicRosterVideo[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  const videos: PublicRosterVideo[] = [];
-
-  for (const item of value) {
-    if (typeof item !== "object" || item === null) {
-      continue;
-    }
-
-    const row = item as Record<string, unknown>;
-    if (
-      typeof row.id !== "string" ||
-      typeof row.youtube_url !== "string" ||
-      typeof row.sort_order !== "number"
-    ) {
-      continue;
-    }
-
-    videos.push({
-      id: row.id,
-      youtube_url: row.youtube_url,
-      sort_order: row.sort_order,
-    });
-  }
-
-  return videos.sort((a, b) => a.sort_order - b.sort_order);
-}
-
-function parseRosterPlayer(value: unknown): PublicRosterPlayer | null {
-  if (typeof value !== "object" || value === null) {
-    return null;
-  }
-
-  const row = value as Record<string, unknown>;
-  if (
-    typeof row.id !== "string" ||
-    typeof row.slug !== "string" ||
-    typeof row.full_name !== "string" ||
-    typeof row.nationality !== "string" ||
-    typeof row.height_cm !== "number"
-  ) {
-    return null;
-  }
-
-  const presentationImageUrl =
-    row.presentation_image_url === null ||
-    typeof row.presentation_image_url === "string"
-      ? row.presentation_image_url
-      : null;
-
-  const lastClub = typeof row.last_club === "string" ? row.last_club : "";
-
-  const categories = parseCategoryRefs(row.player_categories);
-  if (categories.length === 0) {
-    return null;
-  }
-
+function toPublicPlayer(player: RosterPlayer): PublicRosterPlayer {
   return {
-    id: row.id,
-    slug: row.slug,
-    full_name: row.full_name,
-    nationality: row.nationality,
-    height_cm: row.height_cm,
-    last_club: lastClub,
-    presentation_image_url: presentationImageUrl,
-    categories,
-    gallery_images: parseGalleryImages(row.player_gallery_images),
-    videos: parseVideos(row.player_videos),
+    id: player.id,
+    slug: player.id,
+    full_name: player.name,
+    nationality: player.nationality,
+    height_cm: player.heightCm ?? 0,
+    last_club: player.lastClub,
+    presentation_image_url: player.presentationImageUrl,
+    categories:
+      player.categoryId && player.categoryName
+        ? [
+            {
+              id: player.categoryId,
+              name: player.categoryName,
+              slug: player.categoryId,
+            },
+          ]
+        : [],
+    gallery_images: player.gallery.map((image) => ({
+      id: image.id,
+      url: image.url,
+      sort_order: image.sortOrder,
+    })),
+    videos: player.videos.map((video) => ({
+      id: video.id,
+      youtube_url: video.youtubeUrl,
+      sort_order: video.sortOrder,
+    })),
   };
 }
 
-async function playerIdsMatchingAllCategories(
-  categoryIds: string[],
-): Promise<string[]> {
-  const insforge = createInsforgeServer();
-  let intersection: Set<string> | null = null;
-
-  for (const categoryId of categoryIds) {
-    const { data: junctions, error } = await insforge.database
-      .from("player_categories")
-      .select("player_id")
-      .eq("category_id", categoryId);
-
-    if (error) {
-      console.error("[roster/queries/players/categories]", error);
-      throw new Error("Failed to load roster");
-    }
-
-    const ids = new Set<string>();
-    for (const row of junctions ?? []) {
-      const playerId = readPlayerId(row);
-      if (playerId !== null) {
-        ids.add(playerId);
-      }
-    }
-
-    if (intersection === null) {
-      intersection = ids;
-    } else {
-      const next = new Set<string>();
-      for (const playerId of intersection) {
-        if (ids.has(playerId)) {
-          next.add(playerId);
-        }
-      }
-      intersection = next;
-    }
-
-    if (intersection.size === 0) {
-      return [];
-    }
-  }
-
-  return intersection === null ? [] : [...intersection];
+function toPublicCategory(category: RosterCategory): PublicRosterCategory {
+  return {
+    id: category.id,
+    name: category.name,
+    slug: category.id,
+    player_count: 0,
+  };
 }
 
-/**
- * Single public roster player by id: published, not soft deleted, at least one category.
- * Cached per request so layout + page can share one fetch.
- */
 export const getPublicRosterPlayer = cache(
   async (id: string): Promise<PublicRosterPlayer | null> => {
-    const insforge = createInsforgeServer();
-
-    const { data, error } = await insforge.database
-      .from("players")
-      .select(
-        `
-      id,
-      slug,
-      full_name,
-      nationality,
-      height_cm,
-      last_club,
-      presentation_image_url,
-      player_categories!inner(categories(id, name, slug)),
-      player_gallery_images(id, url, sort_order),
-      player_videos(id, youtube_url, sort_order)
-      `,
-      )
-      .eq("id", id)
-      .eq("status", "published")
-      .is("deleted_at", null)
-      .limit(1);
-
-    if (error) {
-      console.error("[roster/queries/players/by-id]", error);
-      throw new Error("Failed to load player");
-    }
-
-    if (!Array.isArray(data) || data.length === 0) {
-      return null;
-    }
-
-    return parseRosterPlayer(data[0]);
+    const player = await getRosterPlayer(db, id);
+    return player ? toPublicPlayer(player) : null;
   },
 );
 
-/**
- * Public roster players: published, not soft deleted, at least one category.
- * Multi category filter uses AND (intersect player id sets per selected `c`).
- */
 export async function listPublicRosterPlayers(
   params: ListPublicRosterPlayersParams = {},
 ): Promise<PublicRosterPlayer[]> {
-  const insforge = createInsforgeServer();
-  const categoryIds = params.categoryIds ?? [];
-
-  let playerIds: string[] | null = null;
-  if (categoryIds.length > 0) {
-    playerIds = await playerIdsMatchingAllCategories(categoryIds);
-    if (playerIds.length === 0) {
-      return [];
-    }
-  }
-
-  let query = insforge.database
-    .from("players")
-    .select(
-      `
-      id,
-      slug,
-      full_name,
-      nationality,
-      height_cm,
-      last_club,
-      presentation_image_url,
-      player_categories!inner(categories(id, name, slug)),
-      player_gallery_images(id, url, sort_order),
-      player_videos(id, youtube_url, sort_order)
-      `,
-    )
-    .eq("status", "published")
-    .is("deleted_at", null)
-    .order("full_name", { ascending: true });
-
-  const trimmed = params.q?.trim() ?? "";
-  if (trimmed.length > 0) {
-    query = query.ilike("full_name", `%${trimmed}%`);
-  }
-
-  if (playerIds !== null) {
-    query = query.in("id", playerIds);
-  }
-
-  const { data, error } = await query;
-
-  if (error) {
-    console.error("[roster/queries/players]", error);
-    throw new Error("Failed to load roster");
-  }
-
-  if (!Array.isArray(data)) {
-    return [];
-  }
-
-  const players: PublicRosterPlayer[] = [];
-  for (const row of data) {
-    const player = parseRosterPlayer(row);
-    if (player !== null) {
-      players.push(player);
-    }
-  }
-
-  return players;
+  const players = await listRosterPlayers(db, params);
+  return players.map(toPublicPlayer);
 }
 
-/**
- * All categories with counts of eligible public roster players only.
- * Counts do not change with the active name or AND filter.
- * Cached per request so home layout + roster grid share one fetch.
- */
 export const listPublicRosterCategories = cache(async (): Promise<
   PublicRosterCategory[]
 > => {
-  const insforge = createInsforgeServer();
-
-  const { data: categories, error: categoriesError } = await insforge.database
-    .from("categories")
-    .select("id, name, slug")
-    .order("name", { ascending: true });
-
-  if (categoriesError) {
-    console.error("[roster/queries/categories]", categoriesError);
-    throw new Error("Failed to load roster categories");
-  }
-
-  const { data: eligiblePlayers, error: playersError } = await insforge.database
-    .from("players")
-    .select("id, player_categories!inner(category_id)")
-    .eq("status", "published")
-    .is("deleted_at", null);
-
-  if (playersError) {
-    console.error("[roster/queries/categories/counts]", playersError);
-    throw new Error("Failed to load roster categories");
-  }
-
-  const counts = new Map<string, number>();
-
-  if (Array.isArray(eligiblePlayers)) {
-    for (const player of eligiblePlayers) {
-      if (typeof player !== "object" || player === null) {
-        continue;
-      }
-
-      const junctions = (player as { player_categories?: unknown })
-        .player_categories;
-      if (!Array.isArray(junctions)) {
-        continue;
-      }
-
-      const seenForPlayer = new Set<string>();
-
-      for (const junction of junctions) {
-        if (
-          typeof junction !== "object" ||
-          junction === null ||
-          !("category_id" in junction)
-        ) {
-          continue;
-        }
-
-        const categoryId = (junction as { category_id: unknown }).category_id;
-        if (typeof categoryId !== "string" || seenForPlayer.has(categoryId)) {
-          continue;
-        }
-
-        seenForPlayer.add(categoryId);
-        counts.set(categoryId, (counts.get(categoryId) ?? 0) + 1);
-      }
-    }
-  }
-
-  if (!Array.isArray(categories)) {
-    return [];
-  }
-
-  const result: PublicRosterCategory[] = [];
-
-  for (const row of categories) {
-    if (typeof row !== "object" || row === null) {
-      continue;
-    }
-
-    const category = row as Record<string, unknown>;
-    if (
-      typeof category.id !== "string" ||
-      typeof category.name !== "string" ||
-      typeof category.slug !== "string"
-    ) {
-      continue;
-    }
-
-    result.push({
-      id: category.id,
-      name: category.name,
-      slug: category.slug,
-      player_count: counts.get(category.id) ?? 0,
-    });
-  }
-
-  return result;
+  const categories = await listRosterCategories(db);
+  return categories.map(toPublicCategory);
 });

--- a/apps/landing/src/lib/roster/queries.ts
+++ b/apps/landing/src/lib/roster/queries.ts
@@ -1,4 +1,5 @@
 import { cache } from "react";
+import { connection } from "next/server";
 import {
   getPublicRosterPlayer as getRosterPlayer,
   listPublicRosterCategories as listRosterCategories,
@@ -59,6 +60,7 @@ function toPublicCategory(category: RosterCategory): PublicRosterCategory {
 
 export const getPublicRosterPlayer = cache(
   async (id: string): Promise<PublicRosterPlayer | null> => {
+    await connection();
     const player = await getRosterPlayer(db, id);
     return player ? toPublicPlayer(player) : null;
   },
@@ -67,6 +69,7 @@ export const getPublicRosterPlayer = cache(
 export async function listPublicRosterPlayers(
   params: ListPublicRosterPlayersParams = {},
 ): Promise<PublicRosterPlayer[]> {
+  await connection();
   const players = await listRosterPlayers(db, params);
   return players.map(toPublicPlayer);
 }
@@ -74,6 +77,7 @@ export async function listPublicRosterPlayers(
 export const listPublicRosterCategories = cache(async (): Promise<
   PublicRosterCategory[]
 > => {
+  await connection();
   const categories = await listRosterCategories(db);
   return categories.map(toPublicCategory);
 });

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "db:push": "drizzle-kit push --config ./src/config/drizzle-kit.ts",
-    "test": "node --import tsx --test src/db/schema.test.ts",
+    "db:grant-landing": "tsx src/scripts/grant-landing-role.ts",
+    "test": "node --import tsx --test --test-concurrency=1 src/db/schema.test.ts src/db/landing-roster.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/database/src/db/landing-role.ts
+++ b/packages/database/src/db/landing-role.ts
@@ -1,0 +1,104 @@
+import { sql } from "drizzle-orm";
+
+import type { Database } from "./client";
+
+/** Production Neon role for the landing app. Create it in Neon; tests use a separate role. */
+export const LANDING_ROLE_NAME = "dtm_landing";
+
+const TEST_LANDING_ROLE_NAME = "dtm_landing_test";
+/** Neon requires ~60-bit password entropy. */
+const TEST_LANDING_ROLE_PASSWORD = "dtm-landing-test-Pw9kQ2mX7nL4vR8w";
+
+function quoteIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function quoteLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function databaseName(connectionString: string): string {
+  const { pathname } = new URL(connectionString);
+  const name = decodeURIComponent(pathname.replace(/^\//, "").split("/")[0] ?? "");
+  return name.length > 0 ? name : "neondb";
+}
+
+export function landingConnectionString(
+  ownerConnectionString: string,
+  user: string,
+  password: string,
+): string {
+  const url = new URL(ownerConnectionString);
+  url.username = user;
+  url.password = password;
+  return url.toString();
+}
+
+export async function grantLandingPrivileges(
+  ownerDb: Database,
+  roleName: string,
+  ownerConnectionString: string,
+): Promise<void> {
+  const role = quoteIdent(roleName);
+  const dbName = quoteIdent(databaseName(ownerConnectionString));
+
+  try {
+    await ownerDb.execute(sql.raw(`GRANT CONNECT ON DATABASE ${dbName} TO ${role}`));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/permission denied|must be owner|cannot grant/i.test(message)) {
+      throw error;
+    }
+  }
+
+  await ownerDb.execute(sql.raw(`GRANT USAGE ON SCHEMA public TO ${role}`));
+  await ownerDb.execute(
+    sql.raw(`REVOKE ALL ON ALL TABLES IN SCHEMA public FROM ${role}`),
+  );
+  await ownerDb.execute(sql.raw(`REVOKE ALL ON SCHEMA better_auth FROM ${role}`));
+  await ownerDb.execute(
+    sql.raw(`REVOKE ALL ON ALL TABLES IN SCHEMA better_auth FROM ${role}`),
+  );
+  await ownerDb.execute(
+    sql.raw(
+      `GRANT SELECT ON roster, roster_gallery_images, roster_videos TO ${role}`,
+    ),
+  );
+  await ownerDb.execute(sql.raw(`GRANT INSERT ON contact_requests TO ${role}`));
+}
+
+export async function ensureTestLandingRole(
+  ownerDb: Database,
+  ownerConnectionString: string,
+): Promise<string> {
+  const role = quoteIdent(TEST_LANDING_ROLE_NAME);
+  const password = quoteLiteral(TEST_LANDING_ROLE_PASSWORD);
+
+  await ownerDb.execute(
+    sql.raw(`
+      DO $do$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT FROM pg_roles WHERE rolname = ${quoteLiteral(TEST_LANDING_ROLE_NAME)}
+        ) THEN
+          CREATE ROLE ${role} WITH LOGIN PASSWORD ${password};
+        ELSE
+          ALTER ROLE ${role} WITH LOGIN PASSWORD ${password};
+        END IF;
+      END
+      $do$;
+    `),
+  );
+
+  await grantLandingPrivileges(
+    ownerDb,
+    TEST_LANDING_ROLE_NAME,
+    ownerConnectionString,
+  );
+
+  return landingConnectionString(
+    ownerConnectionString,
+    TEST_LANDING_ROLE_NAME,
+    TEST_LANDING_ROLE_PASSWORD,
+  );
+}

--- a/packages/database/src/db/landing-roster.test.ts
+++ b/packages/database/src/db/landing-roster.test.ts
@@ -1,0 +1,383 @@
+import assert from "node:assert/strict";
+import { before, beforeEach, test } from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { config } from "dotenv";
+import { eq, sql } from "drizzle-orm";
+
+import { createDatabase, type Database } from "./client";
+import { ensureTestLandingRole } from "./landing-role";
+import {
+  getPublicRosterPlayer,
+  listPublicRosterCategories,
+  listPublicRosterPlayers,
+} from "./roster";
+import {
+  categories,
+  clients,
+  contactRequests,
+  playerGalleryImages,
+  playerVideos,
+  roster,
+  rosterGalleryImages,
+  session,
+  user,
+} from "./schema";
+
+const root = path.resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "../../../..",
+);
+config({ path: path.join(root, ".env") });
+
+const connectionString =
+  process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error("DATABASE_URL or TEST_DATABASE_URL is required");
+}
+
+const db = createDatabase(connectionString);
+let landingDb: Database;
+
+before(async () => {
+  await db.execute(sql`select 1`);
+  const landingUrl = await ensureTestLandingRole(db, connectionString);
+  landingDb = createDatabase(landingUrl);
+});
+
+beforeEach(async () => {
+  await db.execute(
+    sql`truncate table player_gallery_images, player_videos, clients, categories restart identity cascade`,
+  );
+});
+
+function postgresError(error: unknown): object | null {
+  let current: unknown = error;
+  while (typeof current === "object" && current !== null) {
+    if ("code" in current && typeof current.code === "string") {
+      return current;
+    }
+    current = "cause" in current ? current.cause : undefined;
+  }
+  return null;
+}
+
+function isPermissionDenied(error: unknown): boolean {
+  const pgError = postgresError(error);
+  if (pgError && "code" in pgError && pgError.code === "42501") {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return /permission denied/i.test(message);
+}
+
+function eurobasketLink() {
+  return "https://basketball.eurobasket.com/player/Manu-Ginobili/123";
+}
+
+function slugify(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : "category";
+}
+
+async function insertCategory(name: string) {
+  const [row] = await db
+    .insert(categories)
+    .values({ name, slug: slugify(name) })
+    .returning({ id: categories.id });
+
+  if (!row) {
+    throw new Error("insertCategory returned no row");
+  }
+
+  return row;
+}
+
+async function insertPlayer(values: {
+  name: string;
+  visibility: "public" | "private";
+  categoryId?: string;
+  trashedAt?: Date;
+}) {
+  const [row] = await db
+    .insert(clients)
+    .values({
+      kind: "player",
+      name: values.name,
+      nationality: "Argentina",
+      lastClub: "San Antonio Spurs",
+      visibility: values.visibility,
+      eurobasketLink: eurobasketLink(),
+      heightCm: 198,
+      categoryId: values.categoryId,
+      presentationImageUrl: "https://example.com/manu.jpg",
+      trashedAt: values.trashedAt,
+    })
+    .returning({ id: clients.id, name: clients.name });
+
+  if (!row) {
+    throw new Error("insertPlayer returned no row");
+  }
+
+  return row;
+}
+
+test("landing role can read the Roster", async () => {
+  const category = await insertCategory("Guards");
+  await insertPlayer({
+    name: "Manu Ginobili",
+    visibility: "public",
+    categoryId: category.id,
+  });
+
+  const names = (await landingDb.select({ name: roster.name }).from(roster)).map(
+    (row) => row.name,
+  );
+  assert.deepEqual(names, ["Manu Ginobili"]);
+});
+
+test("landing role cannot read private Clients, Users, or the inbox", async () => {
+  await assert.rejects(
+    () => landingDb.select({ id: clients.id }).from(clients),
+    isPermissionDenied,
+  );
+  await assert.rejects(
+    () => landingDb.select({ id: user.id }).from(user),
+    isPermissionDenied,
+  );
+  await assert.rejects(
+    () => landingDb.select({ id: session.id }).from(session),
+    isPermissionDenied,
+  );
+  await assert.rejects(
+    () => landingDb.select({ id: contactRequests.id }).from(contactRequests),
+    isPermissionDenied,
+  );
+  await assert.rejects(
+    () =>
+      landingDb
+        .select({ id: playerGalleryImages.id })
+        .from(playerGalleryImages),
+    isPermissionDenied,
+  );
+});
+
+test("landing role can insert a ContactRequest and cannot read it back", async () => {
+  const email = `landing-role-${Date.now()}@example.com`;
+
+  await landingDb.insert(contactRequests).values({
+    reason: "seeking_representation",
+    email,
+    phone: "+10000000000",
+    message: "I want representation.",
+  });
+
+  await assert.rejects(
+    () =>
+      landingDb
+        .select({ id: contactRequests.id })
+        .from(contactRequests)
+        .where(eq(contactRequests.email, email)),
+    isPermissionDenied,
+  );
+
+  const rows = await db
+    .select({ email: contactRequests.email })
+    .from(contactRequests)
+    .where(eq(contactRequests.email, email));
+  assert.deepEqual(
+    rows.map((row) => row.email),
+    [email],
+  );
+
+  await db.delete(contactRequests).where(eq(contactRequests.email, email));
+});
+
+test("a private Client is not on the Roster", async () => {
+  const category = await insertCategory("Guards");
+  await insertPlayer({
+    name: "Public Player",
+    visibility: "public",
+    categoryId: category.id,
+  });
+  await insertPlayer({
+    name: "Private Player",
+    visibility: "private",
+    categoryId: category.id,
+  });
+
+  const names = (await listPublicRosterPlayers(landingDb)).map(
+    (player) => player.name,
+  );
+  assert.deepEqual(names, ["Public Player"]);
+});
+
+test("a Client in the Trash is not on the Roster", async () => {
+  const category = await insertCategory("Guards");
+  await insertPlayer({
+    name: "Public Player",
+    visibility: "public",
+    categoryId: category.id,
+  });
+  await insertPlayer({
+    name: "Trashed Player",
+    visibility: "public",
+    categoryId: category.id,
+    trashedAt: new Date(),
+  });
+
+  const names = (await listPublicRosterPlayers(landingDb)).map(
+    (player) => player.name,
+  );
+  assert.deepEqual(names, ["Public Player"]);
+});
+
+test("a public Coach is not listed as a Player", async () => {
+  const category = await insertCategory("Guards");
+  await insertPlayer({
+    name: "Manu Ginobili",
+    visibility: "public",
+    categoryId: category.id,
+  });
+  await db.insert(clients).values({
+    kind: "coach",
+    name: "Pat Riley",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+    visibility: "public",
+    eurobasketLink: "https://basketball.eurobasket.com/coach/Pat-Riley/1",
+  });
+
+  const names = (await listPublicRosterPlayers(landingDb)).map(
+    (player) => player.name,
+  );
+  assert.deepEqual(names, ["Manu Ginobili"]);
+});
+
+test("Roster search and Category filter match public Players", async () => {
+  const guards = await insertCategory("Guards");
+  const forwards = await insertCategory("Forwards");
+  await insertPlayer({
+    name: "Manu Ginobili",
+    visibility: "public",
+    categoryId: guards.id,
+  });
+  await insertPlayer({
+    name: "Luis Scola",
+    visibility: "public",
+    categoryId: forwards.id,
+  });
+
+  const search = await listPublicRosterPlayers(landingDb, { q: "Ginobili" });
+  assert.deepEqual(
+    search.map((player) => player.name),
+    ["Manu Ginobili"],
+  );
+
+  const filtered = await listPublicRosterPlayers(landingDb, {
+    categoryIds: [forwards.id],
+  });
+  assert.deepEqual(
+    filtered.map((player) => player.name),
+    ["Luis Scola"],
+  );
+
+  const rosterCategories = await listPublicRosterCategories(landingDb);
+  assert.deepEqual(
+    rosterCategories.map((category) => category.name),
+    ["Forwards", "Guards"],
+  );
+});
+
+test("a public Player with an empty gallery is still on the Roster", async () => {
+  const category = await insertCategory("Guards");
+  const player = await insertPlayer({
+    name: "Manu Ginobili",
+    visibility: "public",
+    categoryId: category.id,
+  });
+
+  const retrieved = await getPublicRosterPlayer(landingDb, player.id);
+  assert.equal(retrieved?.name, "Manu Ginobili");
+  assert.equal(retrieved?.categoryName, "Guards");
+  assert.deepEqual(retrieved?.gallery, []);
+  assert.deepEqual(retrieved?.videos, []);
+});
+
+test("a public Player's gallery and videos are on the Roster", async () => {
+  const category = await insertCategory("Guards");
+  const player = await insertPlayer({
+    name: "Manu Ginobili",
+    visibility: "public",
+    categoryId: category.id,
+  });
+
+  await db.insert(playerGalleryImages).values({
+    clientId: player.id,
+    clientKind: "player",
+    url: "https://example.com/gallery.jpg",
+    sortOrder: 0,
+  });
+  await db.insert(playerVideos).values({
+    clientId: player.id,
+    clientKind: "player",
+    youtubeUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    sortOrder: 0,
+  });
+
+  const retrieved = await getPublicRosterPlayer(landingDb, player.id);
+  assert.equal(retrieved?.gallery[0]?.url, "https://example.com/gallery.jpg");
+  assert.equal(
+    retrieved?.videos[0]?.youtubeUrl,
+    "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  );
+});
+
+test("gallery of a private Player is not on the Roster", async () => {
+  const category = await insertCategory("Guards");
+  const publicPlayer = await insertPlayer({
+    name: "Public Player",
+    visibility: "public",
+    categoryId: category.id,
+  });
+  const privatePlayer = await insertPlayer({
+    name: "Private Player",
+    visibility: "private",
+    categoryId: category.id,
+  });
+
+  await db.insert(playerGalleryImages).values({
+    clientId: publicPlayer.id,
+    clientKind: "player",
+    url: "https://example.com/public.jpg",
+  });
+  await db.insert(playerGalleryImages).values({
+    clientId: privatePlayer.id,
+    clientKind: "player",
+    url: "https://example.com/secret.jpg",
+  });
+
+  const urls = (
+    await landingDb
+      .select({ url: rosterGalleryImages.url })
+      .from(rosterGalleryImages)
+  ).map((row) => row.url);
+  assert.deepEqual(urls, ["https://example.com/public.jpg"]);
+});
+
+test("a private Player is not retrievable on the Roster", async () => {
+  const category = await insertCategory("Guards");
+  const player = await insertPlayer({
+    name: "Private Player",
+    visibility: "private",
+    categoryId: category.id,
+  });
+
+  assert.equal(await getPublicRosterPlayer(landingDb, player.id), null);
+});

--- a/packages/database/src/db/roster.ts
+++ b/packages/database/src/db/roster.ts
@@ -1,0 +1,137 @@
+import { and, asc, eq, ilike, inArray, isNotNull } from "drizzle-orm";
+
+import type { Database } from "./client";
+import {
+  roster,
+  rosterGalleryImages,
+  rosterVideos,
+} from "./schema";
+
+export type RosterPlayer = {
+  id: string;
+  name: string;
+  nationality: string;
+  lastClub: string;
+  heightCm: number | null;
+  categoryId: string | null;
+  categoryName: string | null;
+  presentationImageUrl: string | null;
+  gallery: { id: string; url: string; sortOrder: number }[];
+  videos: { id: string; youtubeUrl: string; sortOrder: number }[];
+};
+
+export type RosterCategory = {
+  id: string;
+  name: string;
+};
+
+export type ListPublicRosterPlayersParams = {
+  q?: string;
+  categoryIds?: string[];
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+const playerColumns = {
+  id: roster.id,
+  name: roster.name,
+  nationality: roster.nationality,
+  lastClub: roster.lastClub,
+  heightCm: roster.heightCm,
+  categoryId: roster.categoryId,
+  categoryName: roster.categoryName,
+  presentationImageUrl: roster.presentationImageUrl,
+} as const;
+
+export async function listPublicRosterPlayers(
+  db: Database,
+  params: ListPublicRosterPlayersParams = {},
+): Promise<RosterPlayer[]> {
+  const filters = [eq(roster.kind, "player")];
+
+  const trimmed = params.q?.trim() ?? "";
+  if (trimmed.length > 0) {
+    filters.push(ilike(roster.name, `%${trimmed}%`));
+  }
+
+  const categoryIds = (params.categoryIds ?? []).filter(isUuid);
+  if (categoryIds.length > 0) {
+    filters.push(inArray(roster.categoryId, categoryIds));
+  }
+
+  const rows = await db
+    .select(playerColumns)
+    .from(roster)
+    .where(and(...filters))
+    .orderBy(asc(roster.name));
+
+  return rows.map((row) => ({ ...row, gallery: [], videos: [] }));
+}
+
+export async function getPublicRosterPlayer(
+  db: Database,
+  id: string,
+): Promise<RosterPlayer | null> {
+  if (!isUuid(id)) {
+    return null;
+  }
+
+  const [row] = await db
+    .select(playerColumns)
+    .from(roster)
+    .where(and(eq(roster.id, id), eq(roster.kind, "player")))
+    .limit(1);
+
+  if (!row) {
+    return null;
+  }
+
+  const gallery = await db
+    .select({
+      id: rosterGalleryImages.id,
+      url: rosterGalleryImages.url,
+      sortOrder: rosterGalleryImages.sortOrder,
+    })
+    .from(rosterGalleryImages)
+    .where(eq(rosterGalleryImages.clientId, id))
+    .orderBy(asc(rosterGalleryImages.sortOrder));
+
+  const videos = await db
+    .select({
+      id: rosterVideos.id,
+      youtubeUrl: rosterVideos.youtubeUrl,
+      sortOrder: rosterVideos.sortOrder,
+    })
+    .from(rosterVideos)
+    .where(eq(rosterVideos.clientId, id))
+    .orderBy(asc(rosterVideos.sortOrder));
+
+  return { ...row, gallery, videos };
+}
+
+export async function listPublicRosterCategories(
+  db: Database,
+): Promise<RosterCategory[]> {
+  const rows = await db
+    .select({
+      id: roster.categoryId,
+      name: roster.categoryName,
+    })
+    .from(roster)
+    .where(and(eq(roster.kind, "player"), isNotNull(roster.categoryId)))
+    .groupBy(roster.categoryId, roster.categoryName)
+    .orderBy(asc(roster.categoryName));
+
+  const categories: RosterCategory[] = [];
+  for (const row of rows) {
+    if (row.id && row.name) {
+      categories.push({ id: row.id, name: row.name });
+    }
+  }
+  return categories;
+}

--- a/packages/database/src/db/schema.ts
+++ b/packages/database/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull, relations, sql } from "drizzle-orm";
 import {
   boolean,
   check,
@@ -258,3 +258,52 @@ export const verification = betterAuthSchema.table("verification", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
 });
+
+export const categoriesRelations = relations(categories, ({ many }) => ({
+  players: many(clients),
+}));
+
+export const clientsRelations = relations(clients, ({ one, many }) => ({
+  category: one(categories, {
+    fields: [clients.categoryId],
+    references: [categories.id],
+  }),
+  galleryImages: many(playerGalleryImages),
+  videos: many(playerVideos),
+}));
+
+export const playerGalleryImagesRelations = relations(
+  playerGalleryImages,
+  ({ one }) => ({
+    client: one(clients, {
+      fields: [playerGalleryImages.clientId, playerGalleryImages.clientKind],
+      references: [clients.id, clients.kind],
+    }),
+  }),
+);
+
+export const playerVideosRelations = relations(playerVideos, ({ one }) => ({
+  client: one(clients, {
+    fields: [playerVideos.clientId, playerVideos.clientKind],
+    references: [clients.id, clients.kind],
+  }),
+}));
+
+export const userRelations = relations(user, ({ many }) => ({
+  sessions: many(session),
+  accounts: many(account),
+}));
+
+export const sessionRelations = relations(session, ({ one }) => ({
+  user: one(user, {
+    fields: [session.userId],
+    references: [user.id],
+  }),
+}));
+
+export const accountRelations = relations(account, ({ one }) => ({
+  user: one(user, {
+    fields: [account.userId],
+    references: [user.id],
+  }),
+}));

--- a/packages/database/src/db/schema.ts
+++ b/packages/database/src/db/schema.ts
@@ -146,12 +146,40 @@ export const roster = pgView("roster").as((qb) =>
       visibility: clients.visibility,
       heightCm: clients.heightCm,
       categoryId: clients.categoryId,
+      categoryName: sql<string | null>`${categories.name}`.as("category_name"),
       presentationImageUrl: clients.presentationImageUrl,
       presentationImageKey: clients.presentationImageKey,
       createdAt: clients.createdAt,
       updatedAt: clients.updatedAt,
     })
     .from(clients)
+    .leftJoin(categories, eq(clients.categoryId, categories.id))
+    .where(and(eq(clients.visibility, "public"), isNull(clients.trashedAt))),
+);
+
+export const rosterGalleryImages = pgView("roster_gallery_images").as((qb) =>
+  qb
+    .select({
+      id: playerGalleryImages.id,
+      clientId: playerGalleryImages.clientId,
+      url: playerGalleryImages.url,
+      sortOrder: playerGalleryImages.sortOrder,
+    })
+    .from(playerGalleryImages)
+    .innerJoin(clients, eq(playerGalleryImages.clientId, clients.id))
+    .where(and(eq(clients.visibility, "public"), isNull(clients.trashedAt))),
+);
+
+export const rosterVideos = pgView("roster_videos").as((qb) =>
+  qb
+    .select({
+      id: playerVideos.id,
+      clientId: playerVideos.clientId,
+      youtubeUrl: playerVideos.youtubeUrl,
+      sortOrder: playerVideos.sortOrder,
+    })
+    .from(playerVideos)
+    .innerJoin(clients, eq(playerVideos.clientId, clients.id))
     .where(and(eq(clients.visibility, "public"), isNull(clients.trashedAt))),
 );
 

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,1 +1,9 @@
 export { createDatabase, schema, type Database } from "./db";
+export {
+  getPublicRosterPlayer,
+  listPublicRosterCategories,
+  listPublicRosterPlayers,
+  type ListPublicRosterPlayersParams,
+  type RosterCategory,
+  type RosterPlayer,
+} from "./db/roster";

--- a/packages/database/src/scripts/grant-landing-role.ts
+++ b/packages/database/src/scripts/grant-landing-role.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { config } from "dotenv";
+
+import { createDatabase } from "../db/client";
+import {
+  grantLandingPrivileges,
+  LANDING_ROLE_NAME,
+} from "../db/landing-role";
+
+const root = path.resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "../../../..",
+);
+config({ path: path.join(root, ".env") });
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error("DATABASE_URL is required");
+}
+
+const db = createDatabase(connectionString);
+await grantLandingPrivileges(db, LANDING_ROLE_NAME, connectionString);
+console.log(`Granted landing privileges to ${LANDING_ROLE_NAME}`);


### PR DESCRIPTION
## Summary
- The landing site reads the Roster from Neon (public Clients that are not in the Trash) with no sign-in and without InsForge
- Landing uses a restricted Postgres role that can SELECT the Roster views and INSERT a ContactRequest, and cannot read private Clients, Users, the inbox, or Better Auth
- Domain-seam tests cover the landing connection vs the dashboard connection

Closes #9

## Test plan
- [x] `pnpm --filter @dtm/database test` (Roster views, landing-role denies, gallery/videos)
- [ ] Open the landing site locally and see public Players without signing in
- [ ] Confirm a private Client and a Client in the Trash do not appear
- [ ] Production: create SQL role `dtm_landing` (not the Neon Roles UI), set the landing project's `DATABASE_URL`, run `pnpm --filter @dtm/database db:grant-landing`


Made with [Cursor](https://cursor.com)