### PR TITLE
Let Staff remove, restore, and delete Clients through the Trash

### DIFF
--- a/apps/dashboard/src/actions/trash/deleteClientFromTrash.ts
+++ b/apps/dashboard/src/actions/trash/deleteClientFromTrash.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { del } from "@vercel/blob";
+import { revalidatePath } from "next/cache";
+
+import { db } from "@/lib/db";
+import { staffActionClient } from "@/lib/safe-action";
+import { clientIdSchema } from "@/lib/validation/clients";
+import { deleteClientFromTrash } from "@/utils/trash";
+
+export const deleteClientFromTrashAction = staffActionClient
+  .metadata({ actionName: "deleteClientFromTrash" })
+  .inputSchema(clientIdSchema)
+  .action(async ({ parsedInput }) => {
+    await deleteClientFromTrash(db, parsedInput.id, async (keys) => {
+      if (keys.length > 0) {
+        await del(keys);
+      }
+    });
+
+    revalidatePath("/trash");
+
+    return { ok: true as const };
+  });

--- a/apps/dashboard/src/actions/trash/restoreClient.ts
+++ b/apps/dashboard/src/actions/trash/restoreClient.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { db } from "@/lib/db";
+import { staffActionClient } from "@/lib/safe-action";
+import { clientIdSchema } from "@/lib/validation/clients";
+import { restoreClient } from "@/utils/trash";
+
+export const restoreClientAction = staffActionClient
+  .metadata({ actionName: "restoreClient" })
+  .inputSchema(clientIdSchema)
+  .action(async ({ parsedInput }) => {
+    await restoreClient(db, parsedInput.id);
+
+    revalidatePath("/players");
+    revalidatePath("/coaches");
+    revalidatePath("/trash");
+    revalidatePath(`/players/${parsedInput.id}`);
+    revalidatePath(`/coaches/${parsedInput.id}`);
+
+    return { ok: true as const };
+  });

--- a/apps/dashboard/src/actions/trash/trashClient.ts
+++ b/apps/dashboard/src/actions/trash/trashClient.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { db } from "@/lib/db";
+import { staffActionClient } from "@/lib/safe-action";
+import { clientIdSchema } from "@/lib/validation/clients";
+import { trashClient } from "@/utils/trash";
+
+export const trashClientAction = staffActionClient
+  .metadata({ actionName: "trashClient" })
+  .inputSchema(clientIdSchema)
+  .action(async ({ parsedInput }) => {
+    await trashClient(db, parsedInput.id);
+
+    revalidatePath("/players");
+    revalidatePath("/coaches");
+    revalidatePath("/trash");
+    revalidatePath(`/players/${parsedInput.id}`);
+    revalidatePath(`/coaches/${parsedInput.id}`);
+
+    return { ok: true as const };
+  });

--- a/apps/dashboard/src/app/(dashboard)/coaches/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/coaches/[id]/page.tsx
@@ -4,6 +4,7 @@ import { ArrowLeftIcon } from "@phosphor-icons/react/dist/ssr";
 
 import { CoachVisibilityCard } from "@/components/coaches/coach-visibility-card";
 import { EditCoachForm } from "@/components/coaches/edit-coach-form";
+import { RemoveToTrashCard } from "@/components/trash/remove-to-trash-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { db } from "@/lib/db";
@@ -49,6 +50,7 @@ export default async function Page({
           coach={coach}
           gaps={coachCompletenessGaps(coach)}
         />
+        <RemoveToTrashCard clientId={coach.id} kind="coach" />
       </div>
     </main>
   );

--- a/apps/dashboard/src/app/(dashboard)/players/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/players/[id]/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeftIcon } from "@phosphor-icons/react/dist/ssr";
 import { EditPlayerForm } from "@/components/players/edit-player-form";
 import { PlayerMedia } from "@/components/players/media/player-media";
 import { PlayerVisibilityCard } from "@/components/players/player-visibility-card";
+import { RemoveToTrashCard } from "@/components/trash/remove-to-trash-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { db } from "@/lib/db";
@@ -63,6 +64,7 @@ export default async function Page({
           gaps={playerCompletenessGaps(player)}
         />
         <PlayerMedia player={player} />
+        <RemoveToTrashCard clientId={player.id} kind="player" />
       </div>
     </main>
   );

--- a/apps/dashboard/src/app/(dashboard)/trash/error.tsx
+++ b/apps/dashboard/src/app/(dashboard)/trash/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { TrashIcon } from "@phosphor-icons/react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+
+export default function Error({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="flex h-full w-full flex-col gap-10 p-10">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-bold">Trash</h1>
+      </div>
+
+      <div className="bg-background rounded-lg border border-border p-4 dark:border-input dark:bg-input/30">
+        <Empty className="min-h-56">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <TrashIcon />
+            </EmptyMedia>
+            <EmptyTitle>Could not load the Trash</EmptyTitle>
+            <EmptyDescription>
+              Something went wrong while loading the Trash. Try again in a
+              moment.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button type="button" onClick={reset}>
+              Try again
+            </Button>
+          </EmptyContent>
+        </Empty>
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/trash/loading.tsx
+++ b/apps/dashboard/src/app/(dashboard)/trash/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="flex h-full w-full flex-col gap-10 p-10">
+      <Skeleton className="h-8 w-24" />
+
+      <div className="bg-background flex h-full w-full flex-col gap-4 rounded-lg border border-border p-4 dark:border-input dark:bg-input/30">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <Skeleton key={index} className="h-16 w-full rounded-lg" />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/src/app/(dashboard)/trash/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/trash/page.tsx
@@ -1,0 +1,87 @@
+import { TrashIcon } from "@phosphor-icons/react/ssr";
+import { desc, isNotNull } from "drizzle-orm";
+import { schema } from "@dtm/database";
+
+import { TrashClientActions } from "@/components/trash/trash-client-actions";
+import { Badge } from "@/components/ui/badge";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemTitle,
+} from "@/components/ui/item";
+import { db } from "@/lib/db";
+
+export default async function Page() {
+  const clients = await db.query.clients.findMany({
+    columns: {
+      id: true,
+      kind: true,
+      name: true,
+      nationality: true,
+      visibility: true,
+    },
+    where: isNotNull(schema.clients.trashedAt),
+    orderBy: [desc(schema.clients.trashedAt)],
+  });
+
+  return (
+    <main className="flex h-full w-full flex-col gap-10 p-10">
+      <h1 className="text-2xl font-bold">Trash</h1>
+
+      <ItemGroup className="bg-background flex h-full w-full flex-col gap-4 rounded-lg border border-border p-4 dark:border-input dark:bg-input/30">
+        {clients.length === 0 ? (
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <TrashIcon />
+              </EmptyMedia>
+              <EmptyTitle>No Clients in the Trash</EmptyTitle>
+              <EmptyDescription>
+                Removed Players and Coaches appear here. Restore keeps
+                Visibility. Delete destroys the Client.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          clients.map((client) => {
+            const kindLabel = client.kind === "player" ? "Player" : "Coach";
+            const visibilityLabel =
+              client.visibility === "public" ? "Public" : "Private";
+
+            return (
+              <Item key={client.id} variant="muted" className="justify-between gap-4">
+                <ItemContent>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <ItemTitle>{client.name}</ItemTitle>
+                    <Badge variant="secondary">{kindLabel}</Badge>
+                  </div>
+                  <ItemDescription>
+                    {[client.nationality, visibilityLabel]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </ItemDescription>
+                </ItemContent>
+                <ItemActions>
+                  <TrashClientActions
+                    clientId={client.id}
+                    clientName={client.name}
+                  />
+                </ItemActions>
+              </Item>
+            );
+          })
+        )}
+      </ItemGroup>
+    </main>
+  );
+}

--- a/apps/dashboard/src/components/sidebar/app-sidebar.tsx
+++ b/apps/dashboard/src/components/sidebar/app-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   EnvelopeSimpleIcon,
   FolderIcon,
   StrategyIcon,
+  TrashIcon,
   UserGearIcon,
   UsersIcon,
 } from "@phosphor-icons/react";
@@ -42,6 +43,11 @@ const clientItems: MenuItem[] = [
     title: "Categories",
     url: "/categories",
     icon: FolderIcon,
+  },
+  {
+    title: "Trash",
+    url: "/trash",
+    icon: TrashIcon,
   },
 ];
 

--- a/apps/dashboard/src/components/trash/remove-to-trash-card.tsx
+++ b/apps/dashboard/src/components/trash/remove-to-trash-card.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useAction } from "next-safe-action/hooks";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { trashClientAction } from "@/actions/trash/trashClient";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+
+export function RemoveToTrashCard({
+  clientId,
+  kind,
+}: {
+  clientId: string;
+  kind: "player" | "coach";
+}) {
+  const router = useRouter();
+  const kindLabel = kind === "player" ? "Player" : "Coach";
+  const listPath = kind === "player" ? "/players" : "/coaches";
+
+  const { executeAsync, isExecuting } = useAction(trashClientAction, {
+    onSuccess: () => {
+      toast.success(`${kindLabel} moved to the Trash.`);
+      router.push(listPath);
+    },
+    onError: ({ error }) => {
+      if (error.serverError) {
+        toast.error(error.serverError.message);
+      }
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader className="border-b">
+        <CardTitle>Trash</CardTitle>
+        <CardDescription>
+          Remove this {kindLabel} to the Trash. They leave this list and the
+          Roster. Restore keeps Visibility.
+        </CardDescription>
+      </CardHeader>
+      <CardFooter className="justify-end py-4">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isExecuting}
+          onClick={() => {
+            void executeAsync({ id: clientId });
+          }}
+        >
+          {isExecuting ? <Spinner /> : "Remove to Trash"}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/components/trash/trash-client-actions.tsx
+++ b/apps/dashboard/src/components/trash/trash-client-actions.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+
+import { useAction } from "next-safe-action/hooks";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { deleteClientFromTrashAction } from "@/actions/trash/deleteClientFromTrash";
+import { restoreClientAction } from "@/actions/trash/restoreClient";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+
+export function TrashClientActions({
+  clientId,
+  clientName,
+}: {
+  clientId: string;
+  clientName: string;
+}) {
+  const router = useRouter();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const { executeAsync: restore, isExecuting: isRestoring } = useAction(
+    restoreClientAction,
+    {
+      onSuccess: () => {
+        toast.success("Client restored.");
+        router.refresh();
+      },
+      onError: ({ error }) => {
+        if (error.serverError) {
+          toast.error(error.serverError.message);
+        }
+      },
+    },
+  );
+
+  const { executeAsync: destroy, isExecuting: isDeleting } = useAction(
+    deleteClientFromTrashAction,
+    {
+      onSuccess: () => {
+        toast.success("Client deleted.");
+        setConfirmOpen(false);
+        router.refresh();
+      },
+      onError: ({ error }) => {
+        if (error.serverError) {
+          toast.error(error.serverError.message);
+        }
+      },
+    },
+  );
+
+  const pending = isRestoring || isDeleting;
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={pending}
+        onClick={() => {
+          void restore({ id: clientId });
+        }}
+      >
+        {isRestoring ? <Spinner /> : "Restore"}
+      </Button>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        disabled={pending}
+        onClick={() => setConfirmOpen(true)}
+      >
+        Delete
+      </Button>
+
+      <AlertDialog
+        open={confirmOpen}
+        onOpenChange={(nextOpen) => {
+          if (!pending) {
+            setConfirmOpen(nextOpen);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this Client?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This destroys {clientName}. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={pending}
+              onClick={(event) => {
+                event.preventDefault();
+                void destroy({ id: clientId });
+              }}
+            >
+              {isDeleting ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/dashboard/src/lib/validation/clients.ts
+++ b/apps/dashboard/src/lib/validation/clients.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const clientIdSchema = z.object({
+  id: z.uuid(),
+});

--- a/apps/dashboard/src/utils/trash.test.ts
+++ b/apps/dashboard/src/utils/trash.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { before, beforeEach, test } from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { eq, sql } from "drizzle-orm";
+import { createDatabase, listPublicRosterPlayers, schema } from "@dtm/database";
+
+import { createCategory } from "./categories";
+import { createCoach, getCoach, setCoachVisibility } from "./coaches";
+import { NotFoundError } from "./errors";
+import { createPlayer, getPlayer, setPlayerVisibility } from "./players";
+import {
+  deleteClientFromTrash,
+  restoreClient,
+  trashClient,
+} from "./trash";
+
+const root = path.resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "../../../../",
+);
+process.loadEnvFile(path.join(root, ".env"));
+
+const connectionString = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error("DATABASE_URL or TEST_DATABASE_URL is required");
+}
+
+const db = createDatabase(connectionString);
+
+before(async () => {
+  await db.execute(sql`select 1`);
+});
+
+beforeEach(async () => {
+  await db.execute(
+    sql`truncate table player_gallery_images, player_videos, clients, categories restart identity cascade`,
+  );
+});
+
+function playerInput() {
+  return {
+    name: "Manu Ginobili",
+    nationality: "Argentina",
+    lastClub: "San Antonio Spurs",
+  };
+}
+
+function coachInput() {
+  return {
+    name: "Pat Riley",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+    eurobasketLink: "https://basketball.eurobasket.com/coach/Pat-Riley/1",
+  };
+}
+
+async function completePublicPlayer() {
+  const category = await createCategory(db, "Guards");
+  const player = await createPlayer(db, {
+    ...playerInput(),
+    heightCm: 198,
+    categoryId: category.id,
+    presentationImageUrl: "https://example.com/manu.jpg",
+  });
+  return setPlayerVisibility(db, player.id, "public");
+}
+
+test("removing a Client to the Trash takes them off the dashboard list", async () => {
+  const player = await createPlayer(db, playerInput());
+  const coach = await createCoach(db, coachInput());
+
+  await trashClient(db, player.id);
+  await trashClient(db, coach.id);
+
+  assert.equal(await getPlayer(db, player.id), null);
+  assert.equal(await getCoach(db, coach.id), null);
+});
+
+test("restore keeps Visibility; public returns to the Roster", async () => {
+  const player = await completePublicPlayer();
+
+  await trashClient(db, player.id);
+
+  assert.equal(await getPlayer(db, player.id), null);
+  assert.deepEqual(
+    (await listPublicRosterPlayers(db)).map((row) => row.name),
+    [],
+  );
+
+  await restoreClient(db, player.id);
+
+  assert.equal((await getPlayer(db, player.id))?.visibility, "public");
+  assert.deepEqual(
+    (await listPublicRosterPlayers(db)).map((row) => row.name),
+    ["Manu Ginobili"],
+  );
+});
+
+test("delete from Trash destroys the Client", async () => {
+  const player = await createPlayer(db, playerInput());
+  await trashClient(db, player.id);
+
+  await deleteClientFromTrash(db, player.id, async () => {});
+
+  assert.equal(await getPlayer(db, player.id), null);
+  await assert.rejects(
+    () => restoreClient(db, player.id),
+    (error: unknown) =>
+      error instanceof NotFoundError && error.message === "Client not found",
+  );
+});
+
+test("delete from Trash destroys Blob objects when they exist", async () => {
+  const player = await createPlayer(db, playerInput());
+  await db
+    .update(schema.clients)
+    .set({ presentationImageKey: "players/manu.jpg" })
+    .where(eq(schema.clients.id, player.id));
+  await db.insert(schema.playerGalleryImages).values({
+    clientId: player.id,
+    url: "https://example.com/gallery.jpg",
+    storageKey: "players/gallery/1.jpg",
+  });
+  await trashClient(db, player.id);
+
+  const deleted: string[] = [];
+  await deleteClientFromTrash(db, player.id, async (keys) => {
+    deleted.push(...keys);
+  });
+
+  assert.deepEqual(deleted.sort(), [
+    "players/gallery/1.jpg",
+    "players/manu.jpg",
+  ]);
+  assert.equal(await getPlayer(db, player.id), null);
+});
+
+test("trashing a Player does not trash a Coach", async () => {
+  const player = await createPlayer(db, {
+    name: "Pat Riley",
+    nationality: "USA",
+    lastClub: "Miami Heat",
+  });
+  const coach = await createCoach(db, coachInput());
+
+  await trashClient(db, player.id);
+
+  assert.equal(await getPlayer(db, player.id), null);
+  assert.equal((await getCoach(db, coach.id))?.name, "Pat Riley");
+});
+
+test("a private Client stays private after restore", async () => {
+  const coach = await createCoach(db, coachInput());
+  await setCoachVisibility(db, coach.id, "public");
+  await setCoachVisibility(db, coach.id, "private");
+
+  await trashClient(db, coach.id);
+  await restoreClient(db, coach.id);
+
+  assert.equal((await getCoach(db, coach.id))?.visibility, "private");
+});

--- a/apps/dashboard/src/utils/trash.ts
+++ b/apps/dashboard/src/utils/trash.ts
@@ -1,0 +1,62 @@
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { schema, type Database } from "@dtm/database";
+
+import { NotFoundError } from "@/utils/errors";
+
+export async function trashClient(db: Database, id: string): Promise<void> {
+  const [row] = await db
+    .update(schema.clients)
+    .set({ trashedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(schema.clients.id, id), isNull(schema.clients.trashedAt)))
+    .returning({ id: schema.clients.id });
+
+  if (!row) {
+    throw new NotFoundError("Client");
+  }
+}
+
+export async function restoreClient(db: Database, id: string): Promise<void> {
+  const [row] = await db
+    .update(schema.clients)
+    .set({ trashedAt: null, updatedAt: new Date() })
+    .where(and(eq(schema.clients.id, id), isNotNull(schema.clients.trashedAt)))
+    .returning({ id: schema.clients.id });
+
+  if (!row) {
+    throw new NotFoundError("Client");
+  }
+}
+
+export async function deleteClientFromTrash(
+  db: Database,
+  id: string,
+  deleteBlobs: (keys: string[]) => Promise<void>,
+): Promise<void> {
+  const client = await db.query.clients.findFirst({
+    columns: {
+      id: true,
+      presentationImageKey: true,
+    },
+    where: and(eq(schema.clients.id, id), isNotNull(schema.clients.trashedAt)),
+    with: {
+      galleryImages: {
+        columns: {
+          storageKey: true,
+        },
+      },
+    },
+  });
+
+  if (!client) {
+    throw new NotFoundError("Client");
+  }
+
+  const blobKeys = [
+    client.presentationImageKey,
+    ...client.galleryImages.map((image) => image.storageKey),
+  ].filter((key): key is string => key != null && key.length > 0);
+
+  await deleteBlobs(blobKeys);
+
+  await db.delete(schema.clients).where(eq(schema.clients.id, id));
+}


### PR DESCRIPTION
## Summary
- Staff and Owner can remove Players and Coaches to the Trash, restore them (Visibility unchanged; public returns to the Roster), or delete them after a confirm step.
- A Trash screen lists removed Clients. Trashing a Player does not trash a Coach. Blob objects are deleted when stored keys exist.
- Domain-seam tests cover remove, restore, delete, Roster exclusion, and Player/Coach independence.

Closes #11

## Test plan
- [ ] Remove a Player to the Trash; they leave `/players` and the Roster if public
- [ ] Remove a Coach to the Trash; they leave `/coaches`
- [ ] Restore keeps Visibility; a public Client returns to the Roster
- [ ] Delete from Trash asks for confirm and destroys the Client
- [ ] Trashing a Player who is also a Coach does not trash the Coach
- [ ] ContactRequests stay in the inbox, not the Trash


Made with [Cursor](https://cursor.com)