### PR TITLE
Add Impeccable and prune unused skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ Desktop.ini
 !.vscode/extensions.json
 !.vscode/settings.json
 
+# Impeccable per-developer overrides
+.impeccable/config.local.json
+
 # Local vendor / agent skill dirs
 .insforge
 .agent

--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,0 +1,3 @@
+{
+  "buildPath": "comp"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,5 @@ This repo uses [Matt Pocock’s engineering skills](https://github.com/mattpococ
 - `/resolving-merge-conflicts` — in-progress merge or rebase conflicts
 - `/writing-for-agents` — edit skills, `AGENTS.md`, or `CLAUDE.md`
 - `/find-skills` — find or install a skill
+
+Impeccable — landing or dashboard UI (design, redesign, critique, polish).

--- a/apps/dashboard/.impeccable/live/config.json
+++ b/apps/dashboard/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["src/app/layout.tsx"],
+  "insertBefore": "</body>",
+  "commentSyntax": "jsx",
+  "cspChecked": true
+}

--- a/apps/dashboard/PRODUCT.md
+++ b/apps/dashboard/PRODUCT.md
@@ -1,0 +1,65 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Owner and Staff of DTM Ones. A User signs in to this dashboard and is not a Client.
+
+- **Staff** manage Clients and ContactRequests, including Trash (remove, restore, delete from Trash). They cannot manage Users.
+- **Owner** can do everything Staff can, and can create Users, change a User’s name (including their own), change a User’s role, and delete Users — not their own role or themselves. The dashboard always has at least one Owner.
+
+The agency’s public primary audience (clubs and scouts on the Roster) is not a user of this app.
+
+## Product Purpose
+
+Internal workspace to maintain Clients (Players and Coaches) and inbound ContactRequests so the public Roster stays accurate and complete.
+
+Success is Staff publishing, hiding, and correcting Clients, and processing inquiries, without this origin becoming the public site.
+
+## Positioning
+
+Staff work for the same FIBA-licensed agency (founded June 2000 by Gustavo Gorini; license 2008019911). This origin is not the Roster. Clubs and scouts do not sign in here.
+
+## Operating Context
+
+- Own origin behind Better Auth (local `http://localhost:3001`; production is its own Vercel project).
+- After sign-in, the default destination is the Contacts inbox (`/contacts`).
+- Other Staff routes: `/players`, `/players/[id]`, `/coaches`, `/coaches/[id]`, `/categories`, `/categories/[id]`, `/trash`. Owner-only: `/users`.
+- Player images upload to Vercel Blob from this app only. The landing site never uploads.
+- Categories are Player positions Staff create and rename. A Category cannot be deleted while any Player has it. Coaches do not have a Category.
+- Restoring a Client from Trash keeps its Visibility; public means it returns to the Roster.
+- Glossary in repo `CONTEXT.md` is binding.
+
+## Capabilities and Constraints
+
+- A Client is a Player or a Coach. Same human doing both is two Clients. Each has Visibility and an Eurobasket link.
+- Public completeness: Player needs name, Category, presentation image, height, nationality, last club, and Eurobasket link. Coach needs name, nationality, last club, and Eurobasket link. A Client may be public only when that kind’s profile is complete.
+- **Confirmed intent:** complete public Coaches belong on the public Roster. The landing app does not list them yet; dashboard still maintains Coaches.
+- Trash holds only Clients. ContactRequests are a separate inbox (reasons: seeking representation, looking for a player).
+- Avoid: Admin (as a type of person), treating Clients as Users, draft/published, Coaches-as-Category.
+- Do not add InsForge tables, storage, Auth, or a JWT bridge.
+- Sibling app: `apps/landing` is the unauthenticated Roster and ContactRequest form.
+
+## Brand Commitments
+
+- Name: DTM Ones / DTM ONES Dashboard.
+- Wordmark assets: `public/assets/dtm-ones-logo.svg`, `public/assets/dtm-ones-logo-black.svg`.
+- Founder and FIBA facts are agency identity; this surface does not need to present them to Staff.
+
+## Evidence on Hand
+
+- Logo SVGs above (confirmed identity).
+- Images under `public/assets/images/` are not confirmed as production Client media. Do not fabricate Clients, quotes, or press.
+
+## Product Principles
+
+1. This app exists so Staff can keep the Roster and inbox true — not so clubs can browse.
+2. Visibility is public or private, gated on completeness; it is not a draft workflow.
+3. Owner vs Staff is the only User distinction.
+4. Trash is Clients only; inquiries stay in Contacts.
+5. Use the glossary’s words; do not invent Admin, talent, or team as domain types.

--- a/apps/landing/.impeccable/live/config.json
+++ b/apps/landing/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["src/app/layout.tsx"],
+  "insertBefore": "</body>",
+  "commentSyntax": "jsx",
+  "cspChecked": true
+}

--- a/apps/landing/PRODUCT.md
+++ b/apps/landing/PRODUCT.md
@@ -1,0 +1,67 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Primary: clubs and scouts browsing the public Roster to find Players or Coaches they might hire.
+
+Also served, not primary: people seeking representation through the contact form.
+
+This origin has no signed-in Users. Staff and Owner work is the dashboard app.
+
+## Product Purpose
+
+Public site for DTM Ones, a basketball agency. It shows the Roster (the public Clients) so a club or scout can evaluate represented talent, and it accepts ContactRequests.
+
+Success is an unauthenticated visitor finding a complete public Player or Coach and sending an inquiry without seeing private Clients, Users, or Staff work.
+
+## Positioning
+
+FIBA-licensed agency founded in June 2000 by Gustavo Gorini, FIBA & JBA Agent (license 2008019911; FIBA Arbitration & Players' Rights). The Roster is the agency’s public Clients — not a marketplace of unaffiliated athletes.
+
+## Operating Context
+
+- Own origin, unauthenticated (local `http://localhost:3000`; production is its own Vercel project).
+- Routes today: `/` Roster (search and Category filters), `/players/[id]`, `/about`, `/contact`.
+- ContactRequest reasons: seeking representation, or looking for a player (a hiring reason; not a Player record and not about a specific Client).
+- A public Client’s Eurobasket link is the external proof profile.
+- Staff publish and hide Clients from the dashboard. This app never uploads media.
+
+## Capabilities and Constraints
+
+- Glossary is binding (`CONTEXT.md`): User, Owner, Staff, Client, Player, Coach, Roster, Visibility, Eurobasket link, Category, Trash, ContactRequest. Avoid Admin, talent, draft/published, team, lead.
+- Visibility is whether a Client is on the Roster. Public only when that kind’s profile is complete. Not a document-draft workflow.
+- Public Player profile: name, Category, presentation image, height, nationality, last club, Eurobasket link. Gallery and videos may be empty.
+- Public Coach profile: name, nationality, last club, Eurobasket link. A Coach does not have Category, presentation image, gallery, or videos.
+- A Client is exactly one of Player or Coach; the same human doing both is two Clients.
+- **Intent vs current:** Coaches must appear on the public Roster. The landing Roster currently lists Players only.
+- **Intent vs current:** a public Client has an Eurobasket link; the landing Player page does not currently expose it.
+- Production landing uses a restricted database role: Roster view `SELECT` and ContactRequest `INSERT` only. It must not read private Clients, Users, or the inbox.
+- Sibling app: `apps/dashboard` maintains Clients and ContactRequests.
+
+## Brand Commitments
+
+- Name: DTM Ones / DTM ONES.
+- Wordmark assets: `public/assets/dtm-ones-logo.svg`, `public/assets/dtm-ones-logo-black.svg`.
+- Founder and FIBA license facts above are binding.
+- Taglines such as “the name talent trusts” and “25 years of uninterrupted work” were not confirmed as locked claims. Do not invent new history, awards, or testimonials.
+
+## Evidence on Hand
+
+- About copy with founder and FIBA facts (confirmed).
+- Logo SVGs above (confirmed identity).
+- Photography under `public/assets/images/` is not confirmed as live Client assets. Do not fabricate people, quotes, press, or case studies.
+- Instagram `@dtm_ones` and the YouTube URL in the site menu are unverified. The current YouTube channel ID matches a well-known placeholder.
+
+## Product Principles
+
+1. The Roster is what clubs and scouts came for: findable, complete, public Clients only.
+2. Players and Coaches are both Clients on the Roster; Coaches are not a Staff-only record.
+3. Agency identity is the wordmark plus founder and FIBA facts — not invented proof.
+4. The public origin never exposes Staff work, private Clients, or Users.
+5. ContactRequests are classified by why they were sent, not by who sent them.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -25,6 +25,12 @@
       "skillPath": "better-auth/emailAndPassword/SKILL.md",
       "computedHash": "7786d722fa682b3d6a99793e73a9d51b59becefa595676134a993020633e068f"
     },
+    "impeccable": {
+      "source": "pbakaus/impeccable",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/impeccable/SKILL.md",
+      "computedHash": "37354ec7825c618102ef4c03062c866f95752d799f7825da69438c697e0ee05e"
+    },
     "next-best-practices": {
       "source": "vercel-labs/next-skills",
       "sourceType": "github",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,35 +13,11 @@
       "skillPath": "security/SKILL.md",
       "computedHash": "ed38caef4b297cc399d717258d6ea4e6ecb8894c453c83450064c7e7c6e5cc02"
     },
-    "brandkit": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/brandkit/SKILL.md",
-      "computedHash": "735007879f5110aeae1e981a53fe74a12afde70347f9773dacd50e4697a091bf"
-    },
     "building-components": {
       "source": "vercel/components.build",
       "sourceType": "github",
       "skillPath": "skills/building-components/SKILL.md",
       "computedHash": "20889af7cb9b3abca1e38824f7fffaa873eb0cc4d45187967b97bd85462cf934"
-    },
-    "create-auth-skill": {
-      "source": "better-auth/skills",
-      "sourceType": "github",
-      "skillPath": "better-auth/create-auth/SKILL.md",
-      "computedHash": "393e8d2d795fa5797c9a4e0665f29183ea2e140233db59746d510340a10456e6"
-    },
-    "design-taste-frontend": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/taste-skill/SKILL.md",
-      "computedHash": "6d838b246d0e35d0b53f4f23f98ba7a1dd561937e64f7d0c7553b0928e376c3e"
-    },
-    "design-taste-frontend-v1": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/taste-skill-v1/SKILL.md",
-      "computedHash": "0a226c13d69639553cf8a7c40aa5527b026820f8ddaf7a6b263988e32ab44a27"
     },
     "email-and-password-best-practices": {
       "source": "better-auth/skills",
@@ -49,71 +25,11 @@
       "skillPath": "better-auth/emailAndPassword/SKILL.md",
       "computedHash": "7786d722fa682b3d6a99793e73a9d51b59becefa595676134a993020633e068f"
     },
-    "frontend-design": {
-      "source": "anthropics/skills",
-      "sourceType": "github",
-      "skillPath": "skills/frontend-design/SKILL.md",
-      "computedHash": "93f53fd1c0352d3d7ec17b8f73d7351bf76f4821e55d123c9d2abc2c53ba48e4"
-    },
-    "full-output-enforcement": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/output-skill/SKILL.md",
-      "computedHash": "524f7c7950c3fde726101613f630140411c7d080e63be718687f4b38f919be81"
-    },
-    "gpt-taste": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/gpt-tasteskill/SKILL.md",
-      "computedHash": "cc8f0c601d8240a124e1d11634351a2be7b8a72fd807c75e5b6bf7afcd5ddee0"
-    },
-    "high-end-visual-design": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/soft-skill/SKILL.md",
-      "computedHash": "7db385e4c5370e5a7fca9704a1361b056e4504ea6a03924bb86f33a4f00b5c73"
-    },
-    "image-to-code": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/image-to-code-skill/SKILL.md",
-      "computedHash": "58517b03b2a01f4c9ba65861559d03df931400871bbc200978c975b24bb92c73"
-    },
-    "imagegen-frontend-mobile": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/imagegen-frontend-mobile/SKILL.md",
-      "computedHash": "9ab7f4f6ce66a3cff02bbf5894e5bd5af50bf5d6ef0adffdc88e8fab772fe44f"
-    },
-    "imagegen-frontend-web": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/imagegen-frontend-web/SKILL.md",
-      "computedHash": "65f5ae59fa317567809438310b1c54f78cd133426deb43e4d3d4ca4c8f541628"
-    },
-    "industrial-brutalist-ui": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/brutalist-skill/SKILL.md",
-      "computedHash": "8fc355c4aadb7d29c53ca28bc41be3cd6eea765d121e3737c4dc2d0f90a8effa"
-    },
-    "minimalist-ui": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/minimalist-skill/SKILL.md",
-      "computedHash": "08873a3131d3be27bef9bf3304b310b16b44ca6e3561aebe532797be3443f6bd"
-    },
     "next-best-practices": {
       "source": "vercel-labs/next-skills",
       "sourceType": "github",
       "skillPath": "skills/next-best-practices/SKILL.md",
       "computedHash": "db85045827ebeb83ac8dbc992b69188755eeb74dcf01cbf5e694d58aa494a106"
-    },
-    "next-cache-components": {
-      "source": "vercel-labs/next-skills",
-      "sourceType": "github",
-      "skillPath": "skills/next-cache-components/SKILL.md",
-      "computedHash": "f835d8226c28abf012cc013928e2627c8a7a046de61127ef229be1711bd1f255"
     },
     "next-upgrade": {
       "source": "vercel-labs/next-skills",
@@ -121,38 +37,10 @@
       "skillPath": "skills/next-upgrade/SKILL.md",
       "computedHash": "e3aeb1f9e8a68d24df0c1c2e3c8ab97ede09a7251a2c76988318d02254346979"
     },
-    "organization-best-practices": {
-      "source": "better-auth/skills",
-      "sourceType": "github",
-      "skillPath": "better-auth/organization/SKILL.md",
-      "computedHash": "fa7a76e45a1f9632e6d63e92b476cf566e64f6e93a2c8ee00bc77b4a74008fbd"
-    },
-    "redesign-existing-projects": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/redesign-skill/SKILL.md",
-      "computedHash": "b405eee0e0e80fc243f731d9aa368bca307e356db7e6157d27101d369dac6726"
-    },
     "shadcn": {
       "source": "shadcn/ui",
       "sourceType": "github",
       "computedHash": "642a177bee320618caa49f5106cadb4e7594c606e867f61ba7b56d19cf745cd5"
-    },
-    "stitch-design-taste": {
-      "source": "Leonxlnx/taste-skill",
-      "sourceType": "github",
-      "skillPath": "skills/stitch-skill/SKILL.md",
-      "computedHash": "13322f38406cd3abf16ba45e35bdc9b18002d0153a79b4612b97aefc65d5a335"
-    },
-    "supabase": {
-      "source": "supabase/agent-skills",
-      "sourceType": "github",
-      "computedHash": "818d65251221019d5fed1d4fb4039866db09d9e4a05f97e536e95c407643b442"
-    },
-    "supabase-postgres-best-practices": {
-      "source": "supabase/agent-skills",
-      "sourceType": "github",
-      "computedHash": "8e41c7417894e6f394614ee7ca3ee5322b1e58d890255d441f42dea98732597f"
     },
     "tanstack-query-best-practices": {
       "source": "deckardger/tanstack-agent-skills",
@@ -165,12 +53,6 @@
       "sourceType": "github",
       "skillPath": "skills/turborepo/SKILL.md",
       "computedHash": "6a23ee82918e35f8848b6fc2ccbea699d740a30fee65f288201adb4e98bf3827"
-    },
-    "two-factor-authentication-best-practices": {
-      "source": "better-auth/skills",
-      "sourceType": "github",
-      "skillPath": "better-auth/twoFactor/SKILL.md",
-      "computedHash": "c4f3a299c62c1985b774b7c28e53b7e55c565dbf973fd52b08899e4bcfffa3f9"
     },
     "vercel-composition-patterns": {
       "source": "vercel-labs/agent-skills",


### PR DESCRIPTION
## Summary
- Pin `pbakaus/impeccable` in `skills-lock.json` and drop the unused taste/stack skills so the lockfile matches the keep list.
- Point `AGENTS.md` at Impeccable for landing and dashboard UI work.
- Record product truth in `apps/landing/PRODUCT.md` and `apps/dashboard/PRODUCT.md`.

Closes #28.

## Test plan
- [ ] `skills-lock.json` contains `impeccable` and only the keep-list skills from #28
- [ ] `AGENTS.md` Skills section still lists Matt Pocock skills plus the Impeccable pointer
- [ ] Landing and dashboard `PRODUCT.md` exist; `.agents/skills/impeccable` is local-only (gitignored)


Made with [Cursor](https://cursor.com)