### PR TITLE
Allow empty private Clients and Coach presentation and gallery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,7 +20,7 @@ A User who can manage Clients and ContactRequests and cannot manage Users. Manag
 ### Roster
 
 **Client**:
-A Player or a Coach the agency represents. A Client is not a User. A Client is exactly one of Player or Coach; the same human doing both is two Clients. A Client has a Visibility and a Eurobasket link.
+A Player or a Coach the agency represents. A Client is not a User. A Client is exactly one of Player or Coach; the same human doing both is two Clients. Kind is required. A Client has a Visibility. Staff create a Client by choosing Player or Coach; name, nationality, last club, and Eurobasket link may be unset while the Client is private. Players and Coaches both have a presentation image and a gallery.
 _Avoid_: User, talent, represented being, super-entity
 
 **Visibility**:
@@ -36,11 +36,11 @@ The public Clients. A private Client is still a Client, not on the Roster.
 _Avoid_: team, catalog, all Clients, the database of Clients
 
 **Player**:
-A basketball player the agency represents. A Player is a Client, is not a User, does not sign in, and is not a Coach. A Player has at most one Category. A public Player has a complete profile: name, Category, presentation image, height, nationality, last club, and Eurobasket link. Gallery and videos may be empty.
+A basketball player the agency represents. A Player is a Client, is not a User, does not sign in, and is not a Coach. A Player has at most one Category, a height, and videos. A public Player has a complete profile: name, Category, presentation image, height, nationality, last club, Eurobasket link, at least one gallery image, and at least one video.
 _Avoid_: User, account, athlete-as-login, Coach-as-Player
 
 **Coach**:
-A basketball coach the agency represents. A Coach is a Client, is not a Player, is not a User, and does not share a Player’s attributes (height, Category, presentation image, gallery, and videos are Player facts). A public Coach has a complete profile: name, nationality, last club, and Eurobasket link.
+A basketball coach the agency represents. A Coach is a Client, is not a Player, is not a User, and does not have height, Category, or videos. A public Coach has a complete profile: name, nationality, last club, Eurobasket link, presentation image, and at least one gallery image.
 _Avoid_: Player, Player tagged “Coaches”
 
 **Trash**:

--- a/apps/dashboard/src/app/(dashboard)/coaches/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/coaches/[id]/page.tsx
@@ -30,7 +30,7 @@ export default async function Page({
       <PageHeader
         backHref="/coaches"
         backLabel="Coaches"
-        title={coach.name}
+        title={coach.name ?? ""}
         description="Coach profile"
         status={isPublic ? "Public" : "Private"}
       />

--- a/apps/dashboard/src/app/(dashboard)/players/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/players/[id]/page.tsx
@@ -45,7 +45,7 @@ export default async function Page({
     <PageShell>
       <PageHeader
         backHref="/players"
-        title={player.name}
+        title={player.name ?? ""}
         description="Player profile"
       />
 

--- a/apps/dashboard/src/components/coaches/edit-coach-form.tsx
+++ b/apps/dashboard/src/components/coaches/edit-coach-form.tsx
@@ -44,9 +44,9 @@ export function EditCoachForm({ coach }: { coach: Coach }) {
     >,
     defaultValues: {
       id: coach.id,
-      name: coach.name,
-      nationality: coach.nationality,
-      lastClub: coach.lastClub,
+      name: coach.name ?? "",
+      nationality: coach.nationality ?? "",
+      lastClub: coach.lastClub ?? "",
       eurobasketLink: coach.eurobasketLink ?? "",
     },
   });

--- a/apps/dashboard/src/components/page/page-frame.tsx
+++ b/apps/dashboard/src/components/page/page-frame.tsx
@@ -146,7 +146,7 @@ export function ListEmpty({
   );
 }
 
-export function ListRowAvatar({ name }: { name: string }) {
+export function ListRowAvatar({ name }: { name: string | null }) {
   return (
     <ItemMedia variant="image">
       <span className="text-muted-foreground text-xs font-medium">

--- a/apps/dashboard/src/components/players/edit-player-form.tsx
+++ b/apps/dashboard/src/components/players/edit-player-form.tsx
@@ -53,9 +53,9 @@ export function EditPlayerForm({
     >,
     defaultValues: {
       id: player.id,
-      name: player.name,
-      nationality: player.nationality,
-      lastClub: player.lastClub,
+      name: player.name ?? "",
+      nationality: player.nationality ?? "",
+      lastClub: player.lastClub ?? "",
       heightCm: player.heightCm == null ? "" : String(player.heightCm),
       categoryId: player.categoryId ?? "",
       eurobasketLink: player.eurobasketLink ?? "",

--- a/apps/dashboard/src/components/trash/trash-client-actions.tsx
+++ b/apps/dashboard/src/components/trash/trash-client-actions.tsx
@@ -28,7 +28,7 @@ export function TrashClientActions({
   clientName,
 }: {
   clientId: string;
-  clientName: string;
+  clientName: string | null;
 }) {
   const router = useRouter();
   const [confirmOpen, setConfirmOpen] = useState(false);

--- a/apps/dashboard/src/types/category.ts
+++ b/apps/dashboard/src/types/category.ts
@@ -10,6 +10,6 @@ export type CategoryWithCount = Category & {
 
 export type CategoryPlayerSummary = {
   id: string;
-  name: string;
-  lastClub: string;
+  name: string | null;
+  lastClub: string | null;
 };

--- a/apps/dashboard/src/types/coach.ts
+++ b/apps/dashboard/src/types/coach.ts
@@ -2,9 +2,9 @@ export type CoachVisibility = "public" | "private";
 
 export type Coach = {
   id: string;
-  name: string;
-  nationality: string;
-  lastClub: string;
+  name: string | null;
+  nationality: string | null;
+  lastClub: string | null;
   eurobasketLink: string | null;
   visibility: CoachVisibility;
 };

--- a/apps/dashboard/src/types/player.ts
+++ b/apps/dashboard/src/types/player.ts
@@ -12,9 +12,9 @@ export type PlayerGalleryImage = {
 
 export type Player = {
   id: string;
-  name: string;
-  nationality: string;
-  lastClub: string;
+  name: string | null;
+  nationality: string | null;
+  lastClub: string | null;
   eurobasketLink: string | null;
   visibility: PlayerVisibility;
   heightCm: number | null;

--- a/apps/dashboard/src/utils/coaches.ts
+++ b/apps/dashboard/src/utils/coaches.ts
@@ -14,20 +14,20 @@ export type CoachWrite = {
 export type CoachPatch = Partial<CoachWrite>;
 
 export function coachCompletenessGaps(coach: {
-  name: string;
-  nationality: string;
-  lastClub: string;
+  name: string | null;
+  nationality: string | null;
+  lastClub: string | null;
   eurobasketLink: string | null;
 }): string[] {
   const gaps: string[] = [];
 
-  if (!coach.name.trim()) {
+  if (!coach.name?.trim()) {
     gaps.push("Name");
   }
-  if (!coach.nationality.trim()) {
+  if (!coach.nationality?.trim()) {
     gaps.push("Nationality");
   }
-  if (!coach.lastClub.trim()) {
+  if (!coach.lastClub?.trim()) {
     gaps.push("Last club");
   }
   if (!coach.eurobasketLink) {
@@ -38,9 +38,9 @@ export function coachCompletenessGaps(coach: {
 }
 
 function isCoachComplete(coach: {
-  name: string;
-  nationality: string;
-  lastClub: string;
+  name: string | null;
+  nationality: string | null;
+  lastClub: string | null;
   eurobasketLink: string | null;
 }): boolean {
   return coachCompletenessGaps(coach).length === 0;

--- a/apps/dashboard/src/utils/list-row.ts
+++ b/apps/dashboard/src/utils/list-row.ts
@@ -1,5 +1,5 @@
-export function personInitials(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
+export function personInitials(name: string | null): string {
+  const parts = (name ?? "").trim().split(/\s+/).filter(Boolean);
   if (parts.length === 0) {
     return "?";
   }

--- a/apps/dashboard/src/utils/players.ts
+++ b/apps/dashboard/src/utils/players.ts
@@ -30,17 +30,17 @@ export type PlayerCompletenessCheck = {
 };
 
 export function playerCompletenessChecks(player: {
-  name: string;
-  nationality: string;
-  lastClub: string;
+  name: string | null;
+  nationality: string | null;
+  lastClub: string | null;
   heightCm: number | null;
   categoryId: string | null;
   presentationImageUrl: string | null;
 }): PlayerCompletenessCheck[] {
   return [
-    { label: "Name", met: Boolean(player.name.trim()) },
-    { label: "Nationality", met: Boolean(player.nationality.trim()) },
-    { label: "Last club", met: Boolean(player.lastClub.trim()) },
+    { label: "Name", met: Boolean(player.name?.trim()) },
+    { label: "Nationality", met: Boolean(player.nationality?.trim()) },
+    { label: "Last club", met: Boolean(player.lastClub?.trim()) },
     { label: "Height", met: player.heightCm != null },
     { label: "Category", met: Boolean(player.categoryId) },
     {
@@ -51,9 +51,9 @@ export function playerCompletenessChecks(player: {
 }
 
 export function playerCompletenessGaps(player: {
-  name: string;
-  nationality: string;
-  lastClub: string;
+  name: string | null;
+  nationality: string | null;
+  lastClub: string | null;
   heightCm: number | null;
   categoryId: string | null;
   presentationImageUrl: string | null;
@@ -64,9 +64,9 @@ export function playerCompletenessGaps(player: {
 }
 
 function isPlayerComplete(player: {
-  name: string;
-  nationality: string;
-  lastClub: string;
+  name: string | null;
+  nationality: string | null;
+  lastClub: string | null;
   heightCm: number | null;
   categoryId: string | null;
   presentationImageUrl: string | null;

--- a/docs/adr/0006-clients-table.md
+++ b/docs/adr/0006-clients-table.md
@@ -1,5 +1,5 @@
 # One `clients` table with a kind
 
-A Client is a Player or a Coach. The database is one `clients` table with `kind` (`player` | `coach`). Shared facts live on that row (name, nationality, last club, Eurobasket link, Visibility). Player-only facts (`height_cm`, `category_id`, presentation image, gallery, videos) are nullable or in Player-only tables, with a CHECK so a Coach cannot have them. The `roster` view is public Clients.
+A Client is a Player or a Coach. The database is one `clients` table with `kind` (`player` | `coach`). Shared facts live on that row (name, nationality, last club, Eurobasket link, Visibility, presentation image) and in the gallery table (both kinds). Player-only facts (`height_cm`, `category_id`, videos) stay nullable on the row or in the videos table, with a CHECK so a Coach cannot have height, Category, or videos. Name, nationality, and last club may be unset while the Client is private. The `roster` view is public Clients.
 
 **Considered:** `clients` plus `player_profiles` (more joins). Separate `players` and `coaches` tables (dashboard lists become a UNION; the word Client exists only in TypeScript).

--- a/packages/database/src/db/roster.ts
+++ b/packages/database/src/db/roster.ts
@@ -72,7 +72,14 @@ export async function listPublicRosterPlayers(
     .where(and(...filters))
     .orderBy(asc(roster.name));
 
-  return rows.map((row) => ({ ...row, gallery: [], videos: [] }));
+  return rows.map((row) => ({
+    ...row,
+    name: row.name ?? "",
+    nationality: row.nationality ?? "",
+    lastClub: row.lastClub ?? "",
+    gallery: [],
+    videos: [],
+  }));
 }
 
 export async function getPublicRosterPlayer(
@@ -113,7 +120,14 @@ export async function getPublicRosterPlayer(
     .where(eq(rosterVideos.clientId, id))
     .orderBy(asc(rosterVideos.sortOrder));
 
-  return { ...row, gallery, videos };
+  return {
+    ...row,
+    name: row.name ?? "",
+    nationality: row.nationality ?? "",
+    lastClub: row.lastClub ?? "",
+    gallery,
+    videos,
+  };
 }
 
 export async function listPublicRosterCategories(

--- a/packages/database/src/db/schema.test.ts
+++ b/packages/database/src/db/schema.test.ts
@@ -140,6 +140,16 @@ function isForeignKeyViolation(error: unknown): boolean {
   );
 }
 
+function isNotNullViolation(error: unknown): boolean {
+  const pgError = postgresError(error);
+  if (!pgError) {
+    return false;
+  }
+
+  const code = "code" in pgError ? pgError.code : undefined;
+  return code === "23502";
+}
+
 function slugify(name: string): string {
   const slug = name
     .trim()
@@ -149,7 +159,74 @@ function slugify(name: string): string {
   return slug.length > 0 ? slug : "category";
 }
 
-test("a Coach cannot store Player facts", async () => {
+test("a Client can omit name, nationality, and last club", async () => {
+  const row = await insertClient({ kind: "player" });
+
+  const [stored] = await db
+    .select({
+      name: clients.name,
+      nationality: clients.nationality,
+      lastClub: clients.lastClub,
+      kind: clients.kind,
+    })
+    .from(clients)
+    .where(eq(clients.id, row.id));
+
+  assert.equal(stored?.kind, "player");
+  assert.equal(stored?.name, null);
+  assert.equal(stored?.nationality, null);
+  assert.equal(stored?.lastClub, null);
+});
+
+test("kind is required and Visibility defaults to private", async () => {
+  await assert.rejects(
+    () =>
+      db.execute(
+        sql`insert into clients (kind, visibility) values (null, 'private')`,
+      ),
+    isNotNullViolation,
+  );
+
+  const row = await insertClient({ kind: "coach" });
+  const [stored] = await db
+    .select({ visibility: clients.visibility })
+    .from(clients)
+    .where(eq(clients.id, row.id));
+
+  assert.equal(stored?.visibility, "private");
+});
+
+test("a Coach can store a presentation image and gallery", async () => {
+  const coach = await insertClient({
+    ...coachValues(),
+    presentationImageUrl: "https://example.com/coach.jpg",
+    presentationImageKey: "clients/coach.jpg",
+  });
+
+  const [stored] = await db
+    .select({
+      presentationImageUrl: clients.presentationImageUrl,
+      presentationImageKey: clients.presentationImageKey,
+    })
+    .from(clients)
+    .where(eq(clients.id, coach.id));
+
+  assert.equal(stored?.presentationImageUrl, "https://example.com/coach.jpg");
+  assert.equal(stored?.presentationImageKey, "clients/coach.jpg");
+
+  const [gallery] = await db
+    .insert(playerGalleryImages)
+    .values({
+      clientId: coach.id,
+      clientKind: "coach",
+      url: "https://example.com/gallery.jpg",
+    })
+    .returning({ url: playerGalleryImages.url });
+
+  assert.equal(gallery?.url, "https://example.com/gallery.jpg");
+});
+
+test("a Coach cannot store height, Category, or videos", async () => {
   const category = await insertCategory("Guards");
   const coach = await insertClient(coachValues());
 
@@ -162,34 +239,6 @@ test("a Coach cannot store Player facts", async () => {
     () => insertClient({ ...coachValues(), categoryId: category.id }),
     (error: unknown) =>
       isCheckViolation(error, "clients_coach_has_no_player_facts"),
-  );
-  await assert.rejects(
-    () =>
-      insertClient({
-        ...coachValues(),
-        presentationImageUrl: "https://example.com/coach.jpg",
-      }),
-    (error: unknown) =>
-      isCheckViolation(error, "clients_coach_has_no_player_facts"),
-  );
-  await assert.rejects(
-    () =>
-      db.insert(playerGalleryImages).values({
-        clientId: coach.id,
-        clientKind: "player",
-        url: "https://example.com/gallery.jpg",
-      }),
-    isForeignKeyViolation,
-  );
-  await assert.rejects(
-    () =>
-      db.insert(playerGalleryImages).values({
-        clientId: coach.id,
-        clientKind: "coach",
-        url: "https://example.com/gallery.jpg",
-      }),
-    (error: unknown) =>
-      isCheckViolation(error, "player_gallery_images_kind_player"),
   );
   await assert.rejects(
     () =>
@@ -209,6 +258,48 @@ test("a Coach cannot store Player facts", async () => {
       }),
     (error: unknown) => isCheckViolation(error, "player_videos_kind_player"),
   );
+});
+
+test("a Player can store height, Category, presentation image, gallery, and videos", async () => {
+  const guards = await insertCategory("Guards");
+  const player = await insertClient({
+    ...playerValues(),
+    categoryId: guards.id,
+    presentationImageUrl: "https://example.com/manu.jpg",
+    presentationImageKey: "clients/manu.jpg",
+  });
+
+  const [gallery] = await db
+    .insert(playerGalleryImages)
+    .values({
+      clientId: player.id,
+      clientKind: "player",
+      url: "https://example.com/gallery.jpg",
+    })
+    .returning({ url: playerGalleryImages.url });
+  const [video] = await db
+    .insert(playerVideos)
+    .values({
+      clientId: player.id,
+      clientKind: "player",
+      youtubeUrl: "https://youtube.com/watch?v=dQw4w9WgXcQ",
+    })
+    .returning({ youtubeUrl: playerVideos.youtubeUrl });
+
+  const [stored] = await db
+    .select({
+      heightCm: clients.heightCm,
+      categoryId: clients.categoryId,
+      presentationImageUrl: clients.presentationImageUrl,
+    })
+    .from(clients)
+    .where(eq(clients.id, player.id));
+
+  assert.equal(stored?.heightCm, 198);
+  assert.equal(stored?.categoryId, guards.id);
+  assert.equal(stored?.presentationImageUrl, "https://example.com/manu.jpg");
+  assert.equal(gallery?.url, "https://example.com/gallery.jpg");
+  assert.equal(video?.youtubeUrl, "https://youtube.com/watch?v=dQw4w9WgXcQ");
 });
 
 test("a Player has at most one Category", async () => {

--- a/packages/database/src/db/schema.ts
+++ b/packages/database/src/db/schema.ts
@@ -53,9 +53,9 @@ export const clients = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     kind: clientKind("kind").notNull(),
-    name: text("name").notNull(),
-    nationality: text("nationality").notNull(),
-    lastClub: text("last_club").notNull(),
+    name: text("name"),
+    nationality: text("nationality"),
+    lastClub: text("last_club"),
     eurobasketLink: text("eurobasket_link"),
     visibility: clientVisibility("visibility").notNull().default("private"),
     trashedAt: timestamp("trashed_at", { withTimezone: true }),
@@ -79,8 +79,6 @@ export const clients = pgTable(
       sql`${table.kind} <> 'coach' OR (
         ${table.heightCm} IS NULL
         AND ${table.categoryId} IS NULL
-        AND ${table.presentationImageUrl} IS NULL
-        AND ${table.presentationImageKey} IS NULL
       )`,
     ),
   ],
@@ -100,10 +98,6 @@ export const playerGalleryImages = pgTable(
       .defaultNow(),
   },
   (table) => [
-    check(
-      "player_gallery_images_kind_player",
-      sql`${table.clientKind} = 'player'`,
-    ),
     foreignKey({
       columns: [table.clientId, table.clientKind],
       foreignColumns: [clients.id, clients.kind],


### PR DESCRIPTION
## Summary
- Make name, nationality, and last club nullable so a private Client can exist with kind only.
- Let a Coach store a presentation image and gallery; height, Category, and videos stay Player-only.
- Amend ADR 0006 and the glossary; extend schema tests for the new allows and remaining forbids.

Closes #36

## Test plan
- [x] Schema tests: omit identity fields; kind required; Visibility defaults to private
- [x] Schema tests: Coach presentation + gallery allowed; height/Category/videos rejected
- [x] Schema tests: Player still has height, Category, presentation, gallery, videos
- [x] Dashboard and landing typecheck
- [x] Full `pnpm test`


Made with [Cursor](https://cursor.com)