### PR TITLE
Let Staff upload a Coach presentation image and gallery

### DIFF
--- a/apps/dashboard/src/actions/players/playerImages.ts
+++ b/apps/dashboard/src/actions/players/playerImages.ts
@@ -21,33 +21,35 @@ export const commitPresentationImageAction = staffActionClient
   .metadata({ actionName: "commitPresentationImage" })
   .inputSchema(commitPlayerImageSchema)
   .action(async ({ parsedInput }) => {
-    const player = await commitPresentationImage(
+    const client = await commitPresentationImage(
       db,
-      parsedInput.playerId,
+      parsedInput.clientId,
       { url: parsedInput.url, pathname: parsedInput.pathname },
       deleteBlobs,
     );
 
     revalidatePath("/clients");
-    revalidatePath(`/players/${parsedInput.playerId}`);
+    revalidatePath(`/players/${parsedInput.clientId}`);
+    revalidatePath(`/coaches/${parsedInput.clientId}`);
 
-    return { ok: true as const, player };
+    return { ok: true as const, client };
   });
 
 export const clearPresentationImageAction = staffActionClient
   .metadata({ actionName: "clearPresentationImage" })
   .inputSchema(clearPresentationImageSchema)
   .action(async ({ parsedInput }) => {
-    const player = await clearPresentationImage(
+    const client = await clearPresentationImage(
       db,
-      parsedInput.playerId,
+      parsedInput.clientId,
       deleteBlobs,
     );
 
     revalidatePath("/clients");
-    revalidatePath(`/players/${parsedInput.playerId}`);
+    revalidatePath(`/players/${parsedInput.clientId}`);
+    revalidatePath(`/coaches/${parsedInput.clientId}`);
 
-    return { ok: true as const, player };
+    return { ok: true as const, client };
   });
 
 export const addPlayerGalleryImageAction = staffActionClient
@@ -56,12 +58,13 @@ export const addPlayerGalleryImageAction = staffActionClient
   .action(async ({ parsedInput }) => {
     const image = await addPlayerGalleryImage(
       db,
-      parsedInput.playerId,
+      parsedInput.clientId,
       { url: parsedInput.url, pathname: parsedInput.pathname },
       deleteBlobs,
     );
 
-    revalidatePath(`/players/${parsedInput.playerId}`);
+    revalidatePath(`/players/${parsedInput.clientId}`);
+    revalidatePath(`/coaches/${parsedInput.clientId}`);
 
     return { ok: true as const, image };
   });
@@ -72,12 +75,13 @@ export const removePlayerGalleryImageAction = staffActionClient
   .action(async ({ parsedInput }) => {
     await removePlayerGalleryImage(
       db,
-      parsedInput.playerId,
+      parsedInput.clientId,
       parsedInput.imageId,
       deleteBlobs,
     );
 
-    revalidatePath(`/players/${parsedInput.playerId}`);
+    revalidatePath(`/players/${parsedInput.clientId}`);
+    revalidatePath(`/coaches/${parsedInput.clientId}`);
 
     return { ok: true as const };
   });

--- a/apps/dashboard/src/app/(dashboard)/coaches/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/coaches/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 
+import { CoachMedia } from "@/components/coaches/coach-media";
 import { CoachVisibilityCard } from "@/components/coaches/coach-visibility-card";
 import { EditCoachForm } from "@/components/coaches/edit-coach-form";
 import {
@@ -7,6 +8,7 @@ import {
   PageHeader,
   PageShell,
 } from "@/components/page/page-frame";
+import { PlayerDetailTabs } from "@/components/players/player-detail-tabs";
 import { RemoveToTrashCard } from "@/components/trash/remove-to-trash-card";
 import { db } from "@/lib/db";
 import { coachCompletenessGaps, getCoach } from "@/utils/coaches";
@@ -14,10 +16,14 @@ import { clientDisplayName } from "@/utils/clients";
 
 export default async function Page({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ tab?: string }>;
 }) {
   const { id } = await params;
+  const sp = await searchParams;
+  const tab = sp.tab === "media" ? "media" : "info";
   const coach = await getCoach(db, id);
 
   if (!coach) {
@@ -35,17 +41,24 @@ export default async function Page({
         status={isPublic ? "Public" : "Private"}
       />
 
-      <DetailLayout
-        main={<EditCoachForm coach={coach} />}
-        rail={
-          <>
-            <CoachVisibilityCard
-              coach={coach}
-              gaps={coachCompletenessGaps(coach)}
-            />
-            <RemoveToTrashCard clientId={coach.id} kind="coach" />
-          </>
+      <PlayerDetailTabs
+        basePath={`/coaches/${coach.id}`}
+        tab={tab}
+        info={
+          <DetailLayout
+            main={<EditCoachForm coach={coach} />}
+            rail={
+              <>
+                <CoachVisibilityCard
+                  coach={coach}
+                  gaps={coachCompletenessGaps(coach)}
+                />
+                <RemoveToTrashCard clientId={coach.id} kind="coach" />
+              </>
+            }
+          />
         }
+        media={<CoachMedia coach={coach} />}
       />
     </PageShell>
   );

--- a/apps/dashboard/src/app/(dashboard)/players/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/players/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function Page({
       />
 
       <PlayerDetailTabs
-        playerId={player.id}
+        basePath={`/players/${player.id}`}
         tab={tab}
         info={
           <DetailLayout

--- a/apps/dashboard/src/app/api/blob/upload/route.ts
+++ b/apps/dashboard/src/app/api/blob/upload/route.ts
@@ -5,10 +5,11 @@ import { env } from "@/config/env";
 import { db } from "@/lib/db";
 import { playerBlobClientPayloadSchema } from "@/lib/validation/players";
 import { getSession } from "@/utils/auth/get-session";
+import { getCoach } from "@/utils/coaches";
 import {
   PLAYER_IMAGE_CONTENT_TYPES,
   PLAYER_IMAGE_MAX_BYTES,
-  isPlayerBlobPathname,
+  isClientBlobPathname,
 } from "@/utils/player-blob-path";
 import { getPlayer } from "@/utils/players";
 
@@ -39,8 +40,9 @@ export async function POST(request: Request): Promise<NextResponse> {
         }
 
         if (
-          !isPlayerBlobPathname(
-            parsed.data.playerId,
+          !isClientBlobPathname(
+            parsed.data.kind,
+            parsed.data.clientId,
             parsed.data.slot,
             pathname,
           )
@@ -48,9 +50,16 @@ export async function POST(request: Request): Promise<NextResponse> {
           throw new Error("Invalid upload path.");
         }
 
-        const player = await getPlayer(db, parsed.data.playerId);
-        if (!player) {
-          throw new Error("Player not found.");
+        const client =
+          parsed.data.kind === "player"
+            ? await getPlayer(db, parsed.data.clientId)
+            : await getCoach(db, parsed.data.clientId);
+        if (!client) {
+          throw new Error(
+            parsed.data.kind === "player"
+              ? "Player not found."
+              : "Coach not found.",
+          );
         }
 
         return {

--- a/apps/dashboard/src/components/coaches/coach-media.tsx
+++ b/apps/dashboard/src/components/coaches/coach-media.tsx
@@ -1,0 +1,20 @@
+import { PlayerGallery } from "@/components/players/media/player-gallery";
+import { PlayerPresentationImage } from "@/components/players/media/player-presentation-image";
+import type { Coach } from "@/types/coach";
+
+export function CoachMedia({ coach }: { coach: Coach }) {
+  return (
+    <div className="flex flex-col gap-6">
+      <PlayerPresentationImage
+        clientId={coach.id}
+        kind="coach"
+        url={coach.presentationImageUrl}
+      />
+      <PlayerGallery
+        clientId={coach.id}
+        kind="coach"
+        images={coach.gallery}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/coaches/edit-coach-form.tsx
+++ b/apps/dashboard/src/components/coaches/edit-coach-form.tsx
@@ -70,7 +70,7 @@ export function EditCoachForm({ coach }: { coach: Coach }) {
           <CardTitle>Profile</CardTitle>
           <CardDescription>
             A public Coach needs name, nationality, last club, and a Eurobasket
-            link. Height, Category, and media are Player facts.
+            link. Height, Category, and videos are Player facts.
           </CardDescription>
         </CardHeader>
         <form

--- a/apps/dashboard/src/components/players/media/player-gallery.tsx
+++ b/apps/dashboard/src/components/players/media/player-gallery.tsx
@@ -33,15 +33,18 @@ import type { PlayerGalleryImage } from "@/types/player";
 import {
   PLAYER_IMAGE_CONTENT_TYPES,
   isAllowedPlayerImage,
+  type ClientBlobKind,
 } from "@/utils/player-blob-path";
 
 import { ImagesIcon, InfoIcon, TrashIcon } from "@phosphor-icons/react";
 
 export function PlayerGallery({
-  playerId,
+  clientId,
+  kind,
   images,
 }: {
-  playerId: string;
+  clientId: string;
+  kind: ClientBlobKind;
   images: PlayerGalleryImage[];
 }) {
   const router = useRouter();
@@ -93,9 +96,9 @@ export function PlayerGallery({
         }
 
         try {
-          const blob = await uploadPlayerImage(playerId, "gallery", file);
+          const blob = await uploadPlayerImage(kind, clientId, "gallery", file);
           const result = await addImage({
-            playerId,
+            clientId,
             url: blob.url,
             pathname: blob.pathname,
           });
@@ -137,7 +140,9 @@ export function PlayerGallery({
       <CardHeader>
         <CardTitle>Gallery Pictures</CardTitle>
         <CardDescription>
-          All the pictures in the player&apos;s page gallery.
+          {kind === "player"
+            ? "All the pictures in the Player's page gallery."
+            : "All the pictures in the Coach's page gallery."}
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
@@ -160,7 +165,9 @@ export function PlayerGallery({
               </EmptyMedia>
               <EmptyTitle>No gallery images yet</EmptyTitle>
               <EmptyDescription>
-                Add photos for the Roster. Gallery may stay empty.
+                {kind === "player"
+                  ? "Add photos for the Roster. Gallery may stay empty."
+                  : "Add photos for this Coach. Gallery may stay empty."}
               </EmptyDescription>
             </EmptyHeader>
           </Empty>
@@ -186,7 +193,7 @@ export function PlayerGallery({
                   disabled={busy}
                   aria-label="Remove gallery image"
                   onClick={() => {
-                    void removeImage({ playerId, imageId: image.id });
+                    void removeImage({ clientId, imageId: image.id });
                   }}
                 >
                   {isRemoving ? <Spinner /> : <TrashIcon className="size-4" />}

--- a/apps/dashboard/src/components/players/media/player-media.tsx
+++ b/apps/dashboard/src/components/players/media/player-media.tsx
@@ -25,10 +25,15 @@ export function PlayerMedia({ player }: { player: PlayerDetail }) {
   return (
     <div className="flex flex-col gap-6">
       <PlayerPresentationImage
-        playerId={player.id}
+        clientId={player.id}
+        kind="player"
         url={player.presentationImageUrl}
       />
-      <PlayerGallery playerId={player.id} images={player.gallery} />
+      <PlayerGallery
+        clientId={player.id}
+        kind="player"
+        images={player.gallery}
+      />
       <Card>
         <CardHeader>
           <CardTitle>YouTube videos</CardTitle>

--- a/apps/dashboard/src/components/players/media/player-presentation-image.tsx
+++ b/apps/dashboard/src/components/players/media/player-presentation-image.tsx
@@ -32,6 +32,7 @@ import { Spinner } from "@/components/ui/spinner";
 import {
   PLAYER_IMAGE_CONTENT_TYPES,
   isAllowedPlayerImage,
+  type ClientBlobKind,
 } from "@/utils/player-blob-path";
 
 import {
@@ -43,10 +44,12 @@ import {
 } from "@phosphor-icons/react";
 
 export function PlayerPresentationImage({
-  playerId,
+  clientId,
+  kind,
   url,
 }: {
-  playerId: string;
+  clientId: string;
+  kind: ClientBlobKind;
   url: string | null;
 }) {
   const router = useRouter();
@@ -97,9 +100,9 @@ export function PlayerPresentationImage({
 
     setUploading(true);
     try {
-      const blob = await uploadPlayerImage(playerId, "presentation", file);
+      const blob = await uploadPlayerImage(kind, clientId, "presentation", file);
       await commit({
-        playerId,
+        clientId,
         url: blob.url,
         pathname: blob.pathname,
       });
@@ -133,7 +136,7 @@ export function PlayerPresentationImage({
           variant="outline"
           disabled={busy}
           onClick={() => {
-            void clear({ playerId });
+            void clear({ clientId });
           }}
         >
           {isClearing ? (
@@ -173,8 +176,9 @@ export function PlayerPresentationImage({
       <CardHeader>
         <CardTitle>Presentation image</CardTitle>
         <CardDescription>
-          This will be the first picture they see for the player, the one
-          displayed on the main roster grid.
+          {kind === "player"
+            ? "This will be the first picture they see for the Player, the one displayed on the main roster grid."
+            : "This is the presentation image for this Coach."}
         </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
@@ -196,7 +200,9 @@ export function PlayerPresentationImage({
               </EmptyMedia>
               <EmptyTitle>No presentation image yet</EmptyTitle>
               <EmptyDescription>
-                Upload a photo so this Player can be public on the Roster.
+                {kind === "player"
+                  ? "Upload a photo so this Player can be public on the Roster."
+                  : "Upload a photo for this Coach."}
               </EmptyDescription>
             </EmptyHeader>
           </Empty>

--- a/apps/dashboard/src/components/players/player-detail-tabs.tsx
+++ b/apps/dashboard/src/components/players/player-detail-tabs.tsx
@@ -10,12 +10,12 @@ import {
 } from "@/components/ui/tabs";
 
 export function PlayerDetailTabs({
-  playerId,
+  basePath,
   tab,
   info,
   media,
 }: {
-  playerId: string;
+  basePath: string;
   tab: "info" | "media";
   info: React.ReactNode;
   media: React.ReactNode;
@@ -26,10 +26,7 @@ export function PlayerDetailTabs({
     <Tabs
       value={tab}
       onValueChange={(value) => {
-        const href =
-          value === "media"
-            ? `/players/${playerId}?tab=media`
-            : `/players/${playerId}`;
+        const href = value === "media" ? `${basePath}?tab=media` : basePath;
         router.replace(href, { scroll: false });
       }}
       className="w-full gap-6"

--- a/apps/dashboard/src/lib/blob-client.ts
+++ b/apps/dashboard/src/lib/blob-client.ts
@@ -1,21 +1,27 @@
 import { upload } from "@vercel/blob/client";
 
 import {
-  playerBlobPathname,
+  clientBlobPathname,
+  type ClientBlobKind,
   type PlayerBlobSlot,
 } from "@/utils/player-blob-path";
 
 export async function uploadPlayerImage(
-  playerId: string,
+  kind: ClientBlobKind,
+  clientId: string,
   slot: PlayerBlobSlot,
   file: File,
 ): Promise<{ url: string; pathname: string }> {
-  const blob = await upload(playerBlobPathname(playerId, slot, file.name), file, {
-    access: "public",
-    handleUploadUrl: "/api/blob/upload",
-    clientPayload: JSON.stringify({ playerId, slot }),
-    contentType: file.type,
-  });
+  const blob = await upload(
+    clientBlobPathname(kind, clientId, slot, file.name),
+    file,
+    {
+      access: "public",
+      handleUploadUrl: "/api/blob/upload",
+      clientPayload: JSON.stringify({ clientId, kind, slot }),
+      contentType: file.type,
+    },
+  );
 
   return { url: blob.url, pathname: blob.pathname };
 }

--- a/apps/dashboard/src/lib/validation/players.ts
+++ b/apps/dashboard/src/lib/validation/players.ts
@@ -71,21 +71,22 @@ export const removePlayerVideoSchema = z.object({
 });
 
 export const playerBlobClientPayloadSchema = z.object({
-  playerId: z.uuid(),
+  clientId: z.uuid(),
+  kind: z.enum(["player", "coach"]),
   slot: z.enum(["presentation", "gallery"]),
 });
 
 export const commitPlayerImageSchema = z.object({
-  playerId: z.uuid(),
+  clientId: z.uuid(),
   url: z.url(),
   pathname: z.string().trim().min(1),
 });
 
 export const clearPresentationImageSchema = z.object({
-  playerId: z.uuid(),
+  clientId: z.uuid(),
 });
 
 export const removePlayerGalleryImageSchema = z.object({
-  playerId: z.uuid(),
+  clientId: z.uuid(),
   imageId: z.uuid(),
 });

--- a/apps/dashboard/src/types/coach.ts
+++ b/apps/dashboard/src/types/coach.ts
@@ -1,5 +1,10 @@
 export type CoachVisibility = "public" | "private";
 
+export type CoachGalleryImage = {
+  id: string;
+  url: string;
+};
+
 export type Coach = {
   id: string;
   name: string | null;
@@ -7,4 +12,6 @@ export type Coach = {
   lastClub: string | null;
   eurobasketLink: string | null;
   visibility: CoachVisibility;
+  presentationImageUrl: string | null;
+  gallery: CoachGalleryImage[];
 };

--- a/apps/dashboard/src/utils/coaches.test.ts
+++ b/apps/dashboard/src/utils/coaches.test.ts
@@ -13,7 +13,15 @@ import {
   setCoachVisibility,
   updateCoach,
 } from "./coaches";
-import { addPlayerVideo, createPlayer, getPlayer } from "./players";
+import {
+  addPlayerGalleryImage,
+  addPlayerVideo,
+  clearPresentationImage,
+  commitPresentationImage,
+  createPlayer,
+  getPlayer,
+  removePlayerGalleryImage,
+} from "./players";
 
 const root = path.resolve(
   fileURLToPath(new URL(".", import.meta.url)),
@@ -82,6 +90,99 @@ test("a Player and a Coach can exist as two Clients", async () => {
   assert.equal(await getCoach(db, player.id), null);
   assert.equal((await getPlayer(db, player.id))?.name, "Pat Riley");
   assert.equal((await getCoach(db, coach.id))?.name, "Pat Riley");
+});
+
+function trackingDeleteBlobs() {
+  const deleted: string[] = [];
+  return {
+    deleted,
+    deleteBlobs: async (keys: string[]) => {
+      deleted.push(...keys);
+    },
+  };
+}
+
+test("commit presentation image stores the URL on the Coach", async () => {
+  const created = await createCoach(db, coachInput());
+  const blobs = trackingDeleteBlobs();
+  const pathname = `coaches/${created.id}/presentation/pat.jpg`;
+  const url = "https://example.com/pat.jpg";
+
+  await commitPresentationImage(
+    db,
+    created.id,
+    { url, pathname },
+    blobs.deleteBlobs,
+  );
+  const retrieved = await getCoach(db, created.id);
+
+  assert.equal(retrieved?.presentationImageUrl, url);
+  assert.deepEqual(blobs.deleted, []);
+});
+
+test("replacing a Coach presentation image deletes the previous Blob", async () => {
+  const created = await createCoach(db, coachInput());
+  const blobs = trackingDeleteBlobs();
+  const firstPath = `coaches/${created.id}/presentation/old.jpg`;
+  const nextPath = `coaches/${created.id}/presentation/new.jpg`;
+
+  await commitPresentationImage(
+    db,
+    created.id,
+    { url: "https://example.com/old.jpg", pathname: firstPath },
+    blobs.deleteBlobs,
+  );
+  await commitPresentationImage(
+    db,
+    created.id,
+    { url: "https://example.com/new.jpg", pathname: nextPath },
+    blobs.deleteBlobs,
+  );
+
+  const retrieved = await getCoach(db, created.id);
+  assert.equal(retrieved?.presentationImageUrl, "https://example.com/new.jpg");
+  assert.deepEqual(blobs.deleted, [firstPath]);
+});
+
+test("gallery images can be added and removed on a Coach", async () => {
+  const created = await createCoach(db, coachInput());
+  const blobs = trackingDeleteBlobs();
+  const pathname = `coaches/${created.id}/gallery/1.jpg`;
+  const url = "https://example.com/gallery.jpg";
+
+  const image = await addPlayerGalleryImage(
+    db,
+    created.id,
+    { url, pathname },
+    blobs.deleteBlobs,
+  );
+  const afterAdd = await getCoach(db, created.id);
+
+  assert.equal(afterAdd?.gallery.length, 1);
+  assert.equal(afterAdd?.gallery[0]?.url, url);
+  assert.deepEqual(blobs.deleted, []);
+
+  await removePlayerGalleryImage(db, created.id, image.id, blobs.deleteBlobs);
+
+  assert.deepEqual((await getCoach(db, created.id))?.gallery, []);
+  assert.deepEqual(blobs.deleted, [pathname]);
+});
+
+test("clear presentation image removes it from the Coach and deletes the Blob", async () => {
+  const created = await createCoach(db, coachInput());
+  const blobs = trackingDeleteBlobs();
+  const pathname = `coaches/${created.id}/presentation/pat.jpg`;
+
+  await commitPresentationImage(
+    db,
+    created.id,
+    { url: "https://example.com/pat.jpg", pathname },
+    blobs.deleteBlobs,
+  );
+  await clearPresentationImage(db, created.id, blobs.deleteBlobs);
+
+  assert.equal((await getCoach(db, created.id))?.presentationImageUrl, null);
+  assert.deepEqual(blobs.deleted, [pathname]);
 });
 
 test("Player media cannot be stored on a Coach", async () => {

--- a/apps/dashboard/src/utils/coaches.ts
+++ b/apps/dashboard/src/utils/coaches.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, asc, eq, isNull } from "drizzle-orm";
 import { schema, type Database } from "@dtm/database";
 
 import type { Coach, CoachVisibility } from "@/types/coach";
@@ -55,15 +55,36 @@ export async function getCoach(db: Database, id: string): Promise<Coach | null> 
       lastClub: true,
       eurobasketLink: true,
       visibility: true,
+      presentationImageUrl: true,
     },
     where: and(
       eq(schema.clients.id, id),
       eq(schema.clients.kind, "coach"),
       isNull(schema.clients.trashedAt),
     ),
+    with: {
+      galleryImages: {
+        columns: {
+          id: true,
+          url: true,
+        },
+        orderBy: [
+          asc(schema.playerGalleryImages.sortOrder),
+          asc(schema.playerGalleryImages.createdAt),
+        ],
+      },
+    },
   });
 
-  return row ?? null;
+  if (!row) {
+    return null;
+  }
+
+  const { galleryImages, ...coach } = row;
+  return {
+    ...coach,
+    gallery: galleryImages,
+  };
 }
 
 export async function createCoach(

--- a/apps/dashboard/src/utils/player-blob-path.test.ts
+++ b/apps/dashboard/src/utils/player-blob-path.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { isAllowedPlayerImage, isPlayerBlobPathname, playerBlobPathname } from "./player-blob-path";
+import { isAllowedPlayerImage, isClientBlobPathname, isPlayerBlobPathname, playerBlobPathname, clientBlobPathname } from "./player-blob-path";
 
 const playerId = "00000000-0000-4000-8000-000000000001";
 const otherId = "00000000-0000-4000-8000-000000000002";
@@ -100,5 +100,33 @@ test("a Blob pathname uses the Player id, slot, and file name", () => {
   assert.equal(
     playerBlobPathname(playerId, "gallery", "C:\\photos\\shot 1.png"),
     `players/${playerId}/gallery/shot-1.png`,
+  );
+});
+
+test("a presentation pathname is bound to that Coach", () => {
+  assert.equal(
+    isClientBlobPathname(
+      "coach",
+      otherId,
+      "presentation",
+      `coaches/${otherId}/presentation/pat.jpg`,
+    ),
+    true,
+  );
+  assert.equal(
+    isClientBlobPathname(
+      "coach",
+      otherId,
+      "presentation",
+      `players/${otherId}/presentation/pat.jpg`,
+    ),
+    false,
+  );
+});
+
+test("a Blob pathname uses the Coach id, slot, and file name", () => {
+  assert.equal(
+    clientBlobPathname("coach", otherId, "gallery", "shot 1.png"),
+    `coaches/${otherId}/gallery/shot-1.png`,
   );
 });

--- a/apps/dashboard/src/utils/player-blob-path.ts
+++ b/apps/dashboard/src/utils/player-blob-path.ts
@@ -2,6 +2,8 @@ export const PLAYER_BLOB_SLOTS = ["presentation", "gallery"] as const;
 
 export type PlayerBlobSlot = (typeof PLAYER_BLOB_SLOTS)[number];
 
+export type ClientBlobKind = "player" | "coach";
+
 export const PLAYER_IMAGE_CONTENT_TYPES = [
   "image/jpeg",
   "image/png",
@@ -20,11 +22,23 @@ export function isAllowedPlayerImage(file: {
   );
 }
 
-export function playerBlobPrefix(
-  playerId: string,
+export function clientBlobPrefix(
+  kind: ClientBlobKind,
+  clientId: string,
   slot: PlayerBlobSlot,
 ): string {
-  return `players/${playerId}/${slot}/`;
+  return `${kind === "player" ? "players" : "coaches"}/${clientId}/${slot}/`;
+}
+
+export function clientBlobPathname(
+  kind: ClientBlobKind,
+  clientId: string,
+  slot: PlayerBlobSlot,
+  fileName: string,
+): string {
+  const base =
+    fileName.split(/[/\\]/).pop()?.replace(/[^\w.\-]+/g, "-") || "image";
+  return `${clientBlobPrefix(kind, clientId, slot)}${base}`;
 }
 
 export function playerBlobPathname(
@@ -32,9 +46,22 @@ export function playerBlobPathname(
   slot: PlayerBlobSlot,
   fileName: string,
 ): string {
-  const base =
-    fileName.split(/[/\\]/).pop()?.replace(/[^\w.\-]+/g, "-") || "image";
-  return `${playerBlobPrefix(playerId, slot)}${base}`;
+  return clientBlobPathname("player", playerId, slot, fileName);
+}
+
+export function isClientBlobPathname(
+  kind: ClientBlobKind,
+  clientId: string,
+  slot: PlayerBlobSlot,
+  pathname: string,
+): boolean {
+  const prefix = clientBlobPrefix(kind, clientId, slot);
+  if (!pathname.startsWith(prefix)) {
+    return false;
+  }
+
+  const rest = pathname.slice(prefix.length);
+  return rest.length > 0 && !rest.includes("..") && !rest.includes("/");
 }
 
 export function isPlayerBlobPathname(
@@ -42,11 +69,5 @@ export function isPlayerBlobPathname(
   slot: PlayerBlobSlot,
   pathname: string,
 ): boolean {
-  const prefix = playerBlobPrefix(playerId, slot);
-  if (!pathname.startsWith(prefix)) {
-    return false;
-  }
-
-  const rest = pathname.slice(prefix.length);
-  return rest.length > 0 && !rest.includes("..") && !rest.includes("/");
+  return isClientBlobPathname("player", playerId, slot, pathname);
 }

--- a/apps/dashboard/src/utils/players.ts
+++ b/apps/dashboard/src/utils/players.ts
@@ -1,9 +1,14 @@
 import { and, asc, eq, isNull } from "drizzle-orm";
 import { schema, type Database } from "@dtm/database";
 
+import type { Coach } from "@/types/coach";
 import type { PlayerDetail, PlayerVisibility } from "@/types/player";
+import { getCoach } from "./coaches";
 import { ConflictError, NotFoundError } from "./errors";
-import { isPlayerBlobPathname } from "./player-blob-path";
+import {
+  isClientBlobPathname,
+  type ClientBlobKind,
+} from "./player-blob-path";
 
 export type DeleteBlobs = (keys: string[]) => Promise<void>;
 
@@ -322,13 +327,28 @@ export async function removePlayerVideo(
   }
 }
 
+function imageBlobKind(
+  clientId: string,
+  slot: "presentation" | "gallery",
+  pathname: string,
+): ClientBlobKind | null {
+  if (isClientBlobPathname("player", clientId, slot, pathname)) {
+    return "player";
+  }
+  if (isClientBlobPathname("coach", clientId, slot, pathname)) {
+    return "coach";
+  }
+  return null;
+}
+
 export async function commitPresentationImage(
   db: Database,
-  playerId: string,
+  clientId: string,
   blob: PlayerImageBlob,
   deleteBlobs: DeleteBlobs,
-): Promise<PlayerDetail> {
-  if (!isPlayerBlobPathname(playerId, "presentation", blob.pathname)) {
+): Promise<PlayerDetail | Coach> {
+  const kind = imageBlobKind(clientId, "presentation", blob.pathname);
+  if (!kind) {
     await deleteBlobs([blob.pathname]);
     throw new ConflictError("Invalid image path.");
   }
@@ -339,15 +359,15 @@ export async function commitPresentationImage(
       presentationImageKey: true,
     },
     where: and(
-      eq(schema.clients.id, playerId),
-      eq(schema.clients.kind, "player"),
+      eq(schema.clients.id, clientId),
+      eq(schema.clients.kind, kind),
       isNull(schema.clients.trashedAt),
     ),
   });
 
   if (!existing) {
     await deleteBlobs([blob.pathname]);
-    throw new NotFoundError("Player");
+    throw new NotFoundError(kind === "player" ? "Player" : "Coach");
   }
 
   try {
@@ -358,7 +378,7 @@ export async function commitPresentationImage(
         presentationImageKey: blob.pathname,
         updatedAt: new Date(),
       })
-      .where(eq(schema.clients.id, playerId));
+      .where(eq(schema.clients.id, clientId));
   } catch (error) {
     await deleteBlobs([blob.pathname]);
     throw error;
@@ -373,22 +393,32 @@ export async function commitPresentationImage(
     }
   }
 
-  const player = await getPlayer(db, playerId);
-  if (!player) {
-    throw new NotFoundError("Player");
+  if (kind === "player") {
+    const player = await getPlayer(db, clientId);
+    if (!player) {
+      throw new NotFoundError("Player");
+    }
+
+    return player;
   }
 
-  return player;
+  const coach = await getCoach(db, clientId);
+  if (!coach) {
+    throw new NotFoundError("Coach");
+  }
+
+  return coach;
 }
 
 export async function clearPresentationImage(
   db: Database,
-  playerId: string,
+  clientId: string,
   deleteBlobs: DeleteBlobs,
-): Promise<PlayerDetail> {
+): Promise<PlayerDetail | Coach> {
   const existing = await db.query.clients.findFirst({
     columns: {
       id: true,
+      kind: true,
       name: true,
       nationality: true,
       lastClub: true,
@@ -399,25 +429,26 @@ export async function clearPresentationImage(
       presentationImageKey: true,
     },
     where: and(
-      eq(schema.clients.id, playerId),
-      eq(schema.clients.kind, "player"),
+      eq(schema.clients.id, clientId),
       isNull(schema.clients.trashedAt),
     ),
   });
 
   if (!existing) {
-    throw new NotFoundError("Player");
+    throw new NotFoundError("Client");
   }
 
-  const next = {
-    ...existing,
-    presentationImageUrl: null,
-  };
+  if (existing.kind === "player") {
+    const next = {
+      ...existing,
+      presentationImageUrl: null,
+    };
 
-  if (existing.visibility === "public" && !isPlayerComplete(next)) {
-    throw new ConflictError(
-      "A Player cannot be public unless the profile is complete.",
-    );
+    if (existing.visibility === "public" && !isPlayerComplete(next)) {
+      throw new ConflictError(
+        "A Player cannot be public unless the profile is complete.",
+      );
+    }
   }
 
   await db
@@ -427,43 +458,56 @@ export async function clearPresentationImage(
       presentationImageKey: null,
       updatedAt: new Date(),
     })
-    .where(eq(schema.clients.id, playerId));
+    .where(eq(schema.clients.id, clientId));
 
   if (existing.presentationImageKey) {
     await deleteBlobs([existing.presentationImageKey]);
   }
 
-  const player = await getPlayer(db, playerId);
-  if (!player) {
-    throw new NotFoundError("Player");
+  if (existing.kind === "player") {
+    const player = await getPlayer(db, clientId);
+    if (!player) {
+      throw new NotFoundError("Player");
+    }
+
+    return player;
   }
 
-  return player;
+  const coach = await getCoach(db, clientId);
+  if (!coach) {
+    throw new NotFoundError("Coach");
+  }
+
+  return coach;
 }
 
 export async function addPlayerGalleryImage(
   db: Database,
-  playerId: string,
+  clientId: string,
   blob: PlayerImageBlob,
   deleteBlobs: DeleteBlobs,
 ): Promise<{ id: string; url: string }> {
-  if (!isPlayerBlobPathname(playerId, "gallery", blob.pathname)) {
+  const kind = imageBlobKind(clientId, "gallery", blob.pathname);
+  if (!kind) {
     await deleteBlobs([blob.pathname]);
     throw new ConflictError("Invalid image path.");
   }
 
-  const existing = await getPlayer(db, playerId);
+  const existing =
+    kind === "player"
+      ? await getPlayer(db, clientId)
+      : await getCoach(db, clientId);
   if (!existing) {
     await deleteBlobs([blob.pathname]);
-    throw new NotFoundError("Player");
+    throw new NotFoundError(kind === "player" ? "Player" : "Coach");
   }
 
   try {
     const [row] = await db
       .insert(schema.playerGalleryImages)
       .values({
-        clientId: playerId,
-        clientKind: "player",
+        clientId,
+        clientKind: kind,
         url: blob.url,
         storageKey: blob.pathname,
         sortOrder: existing.gallery.length,


### PR DESCRIPTION
## Summary
- Staff can set, replace, and clear a Coach presentation image, and add or remove gallery images, using the same dashboard Blob uploads as Players.
- The Coach screen gets an Info / Media split with no videos. Adding a video to a Coach still fails.
- Player presentation, gallery, and YouTube videos are unchanged. Landing still does not upload.

Closes #38

## Test plan
- [ ] On a Coach, upload and replace a presentation image
- [ ] Remove a Coach presentation image
- [ ] Add and remove Coach gallery images
- [ ] Uploads go through the dashboard Blob token, not landing
- [ ] Adding a YouTube video on a Coach is rejected
- [ ] A Player can still set presentation, gallery, and videos


Made with [Cursor](https://cursor.com)