### PR TITLE
Require a complete profile before a Player or Coach can be public. (#39)

### DIFF
--- a/apps/dashboard/src/components/coaches/coach-visibility-card.tsx
+++ b/apps/dashboard/src/components/coaches/coach-visibility-card.tsx
@@ -2,6 +2,7 @@
 
 import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { toast } from "sonner";
 
 import { EyeSlashIcon, GlobeSimpleIcon } from "@phosphor-icons/react";
@@ -72,7 +73,16 @@ export function CoachVisibilityCard({
             <ul className="flex flex-col gap-2">
               {gaps.map((gap) => (
                 <li key={gap} className="text-sm">
-                  {gap}
+                  {gap === "Presentation image" || gap === "Gallery image" ? (
+                    <Link
+                      href={`/coaches/${coach.id}?tab=media`}
+                      className="underline underline-offset-2"
+                    >
+                      {gap}
+                    </Link>
+                  ) : (
+                    gap
+                  )}
                 </li>
               ))}
             </ul>

--- a/apps/dashboard/src/components/players/player-visibility-card.tsx
+++ b/apps/dashboard/src/components/players/player-visibility-card.tsx
@@ -63,7 +63,10 @@ function RequirementList({
               <CircleIcon aria-hidden className="mt-0.5 size-4 shrink-0" />
             )}
             <span className={muted ? "text-muted-foreground" : "font-medium"}>
-              {check.label === "Presentation image" && !check.met ? (
+              {(check.label === "Presentation image" ||
+                check.label === "Gallery image" ||
+                check.label === "Video") &&
+              !check.met ? (
                 <Link
                   href={`/players/${playerId}?tab=media`}
                   className="underline underline-offset-2"

--- a/apps/dashboard/src/utils/coaches.test.ts
+++ b/apps/dashboard/src/utils/coaches.test.ts
@@ -59,10 +59,33 @@ function eurobasketLink() {
 }
 
 async function completeCoach() {
-  return createCoach(db, {
+  const created = await createCoach(db, {
     ...coachInput(),
     eurobasketLink: eurobasketLink(),
   });
+  await commitPresentationImage(
+    db,
+    created.id,
+    {
+      url: "https://example.com/pat.jpg",
+      pathname: `coaches/${created.id}/presentation/pat.jpg`,
+    },
+    async () => {},
+  );
+  await addPlayerGalleryImage(
+    db,
+    created.id,
+    {
+      url: "https://example.com/gallery.jpg",
+      pathname: `coaches/${created.id}/gallery/1.jpg`,
+    },
+    async () => {},
+  );
+  const coach = await getCoach(db, created.id);
+  if (!coach) {
+    throw new Error("completeCoach could not load coach");
+  }
+  return coach;
 }
 
 test("create Coach makes a private Client retrievable by the returned id", async () => {
@@ -214,6 +237,23 @@ test("a Coach cannot be public unless the profile is complete", async () => {
   assert.equal((await getCoach(db, created.id))?.visibility, "private");
 });
 
+test("a Coach cannot be public without presentation image and gallery", async () => {
+  const created = await createCoach(db, {
+    ...coachInput(),
+    eurobasketLink: eurobasketLink(),
+  });
+
+  await assert.rejects(
+    () => setCoachVisibility(db, created.id, "public"),
+    (error: unknown) =>
+      error instanceof ConflictError &&
+      error.message ===
+        "A Coach cannot be public unless the profile is complete.",
+  );
+
+  assert.equal((await getCoach(db, created.id))?.visibility, "private");
+});
+
 test("a complete Coach can be public", async () => {
   const created = await completeCoach();
 
@@ -247,6 +287,45 @@ test("editing a public Coach refuses an incomplete profile", async () => {
   );
 
   assert.equal((await getCoach(db, created.id))?.eurobasketLink, eurobasketLink());
+});
+
+test("a public Coach cannot clear the presentation image", async () => {
+  const created = await completeCoach();
+  await setCoachVisibility(db, created.id, "public");
+  const blobs = trackingDeleteBlobs();
+
+  await assert.rejects(
+    () => clearPresentationImage(db, created.id, blobs.deleteBlobs),
+    (error: unknown) =>
+      error instanceof ConflictError &&
+      error.message ===
+        "A Coach cannot be public unless the profile is complete.",
+  );
+
+  assert.equal(
+    (await getCoach(db, created.id))?.presentationImageUrl,
+    "https://example.com/pat.jpg",
+  );
+  assert.deepEqual(blobs.deleted, []);
+});
+
+test("a public Coach cannot lose the last gallery image", async () => {
+  const created = await completeCoach();
+  await setCoachVisibility(db, created.id, "public");
+  const blobs = trackingDeleteBlobs();
+  const imageId = created.gallery[0]?.id;
+  assert.ok(imageId);
+
+  await assert.rejects(
+    () => removePlayerGalleryImage(db, created.id, imageId, blobs.deleteBlobs),
+    (error: unknown) =>
+      error instanceof ConflictError &&
+      error.message ===
+        "A Coach cannot be public unless the profile is complete.",
+  );
+
+  assert.equal((await getCoach(db, created.id))?.gallery.length, 1);
+  assert.deepEqual(blobs.deleted, []);
 });
 
 test("get Coach returns null for an id that does not exist", async () => {

--- a/apps/dashboard/src/utils/coaches.ts
+++ b/apps/dashboard/src/utils/coaches.ts
@@ -13,12 +13,18 @@ export type CoachWrite = {
 
 export type CoachPatch = Partial<CoachWrite>;
 
-export function coachCompletenessGaps(coach: {
+type CoachCompletenessInput = {
   name: string | null;
   nationality: string | null;
   lastClub: string | null;
   eurobasketLink: string | null;
-}): string[] {
+  presentationImageUrl: string | null;
+  gallery: { length: number };
+};
+
+export function coachCompletenessGaps(
+  coach: CoachCompletenessInput,
+): string[] {
   const gaps: string[] = [];
 
   if (!coach.name?.trim()) {
@@ -30,19 +36,20 @@ export function coachCompletenessGaps(coach: {
   if (!coach.lastClub?.trim()) {
     gaps.push("Last club");
   }
-  if (!coach.eurobasketLink) {
+  if (!coach.eurobasketLink?.trim()) {
     gaps.push("Eurobasket link");
+  }
+  if (!coach.presentationImageUrl) {
+    gaps.push("Presentation image");
+  }
+  if (coach.gallery.length === 0) {
+    gaps.push("Gallery image");
   }
 
   return gaps;
 }
 
-function isCoachComplete(coach: {
-  name: string | null;
-  nationality: string | null;
-  lastClub: string | null;
-  eurobasketLink: string | null;
-}): boolean {
+export function isCoachComplete(coach: CoachCompletenessInput): boolean {
   return coachCompletenessGaps(coach).length === 0;
 }
 
@@ -133,6 +140,8 @@ export async function updateCoach(
       patch.eurobasketLink === undefined
         ? existing.eurobasketLink
         : patch.eurobasketLink,
+    presentationImageUrl: existing.presentationImageUrl,
+    gallery: existing.gallery,
   };
 
   if (existing.visibility === "public" && !isCoachComplete(next)) {
@@ -143,7 +152,13 @@ export async function updateCoach(
 
   await db
     .update(schema.clients)
-    .set({ ...next, updatedAt: new Date() })
+    .set({
+      name: next.name,
+      nationality: next.nationality,
+      lastClub: next.lastClub,
+      eurobasketLink: next.eurobasketLink,
+      updatedAt: new Date(),
+    })
     .where(eq(schema.clients.id, id));
 
   const coach = await getCoach(db, id);

--- a/apps/dashboard/src/utils/player-completeness.test.ts
+++ b/apps/dashboard/src/utils/player-completeness.test.ts
@@ -13,6 +13,9 @@ const complete = {
   heightCm: 198,
   categoryId: "guards",
   presentationImageUrl: "https://example.com/manu.jpg",
+  eurobasketLink: "https://basketball.eurobasket.com/player/Manu-Ginobili/1",
+  gallery: [{ id: "g1" }],
+  videos: [{ id: "v1" }],
 };
 
 test("playerCompletenessChecks marks missing fields as unmet", () => {
@@ -21,11 +24,21 @@ test("playerCompletenessChecks marks missing fields as unmet", () => {
     lastClub: "  ",
     heightCm: null,
     presentationImageUrl: null,
+    eurobasketLink: null,
+    gallery: [],
+    videos: [],
   })
     .filter((check) => !check.met)
     .map((check) => check.label);
 
-  assert.deepEqual(unmet, ["Last club", "Height", "Presentation image"]);
+  assert.deepEqual(unmet, [
+    "Last club",
+    "Height",
+    "Presentation image",
+    "Eurobasket link",
+    "Gallery image",
+    "Video",
+  ]);
 });
 
 test("playerCompletenessGaps is the unmet labels", () => {

--- a/apps/dashboard/src/utils/players.test.ts
+++ b/apps/dashboard/src/utils/players.test.ts
@@ -16,6 +16,7 @@ import {
   createPlayer,
   getPlayer,
   removePlayerGalleryImage,
+  removePlayerVideo,
   setPlayerVisibility,
   updatePlayer,
 } from "./players";
@@ -53,12 +54,32 @@ function playerInput() {
 
 async function completePlayer() {
   const category = await createCategory(db, "Guards");
-  return createPlayer(db, {
+  const created = await createPlayer(db, {
     ...playerInput(),
     heightCm: 198,
     categoryId: category.id,
     presentationImageUrl: "https://example.com/manu.jpg",
+    eurobasketLink: "https://basketball.eurobasket.com/player/Manu-Ginobili/1",
   });
+  await addPlayerVideo(
+    db,
+    created.id,
+    "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  );
+  await addPlayerGalleryImage(
+    db,
+    created.id,
+    {
+      url: "https://example.com/gallery.jpg",
+      pathname: `players/${created.id}/gallery/1.jpg`,
+    },
+    async () => {},
+  );
+  const player = await getPlayer(db, created.id);
+  if (!player) {
+    throw new Error("completePlayer could not load player");
+  }
+  return player;
 }
 
 test("create Player makes a private Client retrievable by the returned id", async () => {
@@ -93,6 +114,26 @@ test("a Player has at most one Category", async () => {
 
 test("a Player cannot be public unless the profile is complete", async () => {
   const created = await createPlayer(db, playerInput());
+
+  await assert.rejects(
+    () => setPlayerVisibility(db, created.id, "public"),
+    (error: unknown) =>
+      error instanceof ConflictError &&
+      error.message ===
+        "A Player cannot be public unless the profile is complete.",
+  );
+
+  assert.equal((await getPlayer(db, created.id))?.visibility, "private");
+});
+
+test("a Player cannot be public without Eurobasket link, gallery, or videos", async () => {
+  const category = await createCategory(db, "Guards");
+  const created = await createPlayer(db, {
+    ...playerInput(),
+    heightCm: 198,
+    categoryId: category.id,
+    presentationImageUrl: "https://example.com/manu.jpg",
+  });
 
   await assert.rejects(
     () => setPlayerVisibility(db, created.id, "public"),
@@ -297,6 +338,42 @@ test("a public Player cannot clear the presentation image", async () => {
     "https://example.com/manu.jpg",
   );
   assert.deepEqual(blobs.deleted, []);
+});
+
+test("a public Player cannot lose the last gallery image", async () => {
+  const created = await completePlayer();
+  await setPlayerVisibility(db, created.id, "public");
+  const blobs = trackingDeleteBlobs();
+  const imageId = created.gallery[0]?.id;
+  assert.ok(imageId);
+
+  await assert.rejects(
+    () => removePlayerGalleryImage(db, created.id, imageId, blobs.deleteBlobs),
+    (error: unknown) =>
+      error instanceof ConflictError &&
+      error.message ===
+        "A Player cannot be public unless the profile is complete.",
+  );
+
+  assert.equal((await getPlayer(db, created.id))?.gallery.length, 1);
+  assert.deepEqual(blobs.deleted, []);
+});
+
+test("a public Player cannot lose the last video", async () => {
+  const created = await completePlayer();
+  await setPlayerVisibility(db, created.id, "public");
+  const videoId = created.videos[0]?.id;
+  assert.ok(videoId);
+
+  await assert.rejects(
+    () => removePlayerVideo(db, created.id, videoId),
+    (error: unknown) =>
+      error instanceof ConflictError &&
+      error.message ===
+        "A Player cannot be public unless the profile is complete.",
+  );
+
+  assert.equal((await getPlayer(db, created.id))?.videos.length, 1);
 });
 
 test("gallery images can be added and are retrievable", async () => {

--- a/apps/dashboard/src/utils/players.ts
+++ b/apps/dashboard/src/utils/players.ts
@@ -3,7 +3,7 @@ import { schema, type Database } from "@dtm/database";
 
 import type { Coach } from "@/types/coach";
 import type { PlayerDetail, PlayerVisibility } from "@/types/player";
-import { getCoach } from "./coaches";
+import { getCoach, isCoachComplete } from "./coaches";
 import { ConflictError, NotFoundError } from "./errors";
 import {
   isClientBlobPathname,
@@ -34,14 +34,21 @@ export type PlayerCompletenessCheck = {
   met: boolean;
 };
 
-export function playerCompletenessChecks(player: {
+type PlayerCompletenessInput = {
   name: string | null;
   nationality: string | null;
   lastClub: string | null;
   heightCm: number | null;
   categoryId: string | null;
   presentationImageUrl: string | null;
-}): PlayerCompletenessCheck[] {
+  eurobasketLink: string | null;
+  gallery: { length: number };
+  videos: { length: number };
+};
+
+export function playerCompletenessChecks(
+  player: PlayerCompletenessInput,
+): PlayerCompletenessCheck[] {
   return [
     { label: "Name", met: Boolean(player.name?.trim()) },
     { label: "Nationality", met: Boolean(player.nationality?.trim()) },
@@ -52,30 +59,21 @@ export function playerCompletenessChecks(player: {
       label: "Presentation image",
       met: Boolean(player.presentationImageUrl),
     },
+    { label: "Eurobasket link", met: Boolean(player.eurobasketLink?.trim()) },
+    { label: "Gallery image", met: player.gallery.length > 0 },
+    { label: "Video", met: player.videos.length > 0 },
   ];
 }
 
-export function playerCompletenessGaps(player: {
-  name: string | null;
-  nationality: string | null;
-  lastClub: string | null;
-  heightCm: number | null;
-  categoryId: string | null;
-  presentationImageUrl: string | null;
-}): string[] {
+export function playerCompletenessGaps(
+  player: PlayerCompletenessInput,
+): string[] {
   return playerCompletenessChecks(player)
     .filter((check) => !check.met)
     .map((check) => check.label);
 }
 
-function isPlayerComplete(player: {
-  name: string | null;
-  nationality: string | null;
-  lastClub: string | null;
-  heightCm: number | null;
-  categoryId: string | null;
-  presentationImageUrl: string | null;
-}): boolean {
+function isPlayerComplete(player: PlayerCompletenessInput): boolean {
   return playerCompletenessGaps(player).length === 0;
 }
 
@@ -219,6 +217,8 @@ export async function updatePlayer(
       patch.eurobasketLink === undefined
         ? existing.eurobasketLink
         : patch.eurobasketLink,
+    gallery: existing.gallery,
+    videos: existing.videos,
   };
 
   if (existing.visibility === "public" && !isPlayerComplete(next)) {
@@ -230,7 +230,16 @@ export async function updatePlayer(
   try {
     await db
       .update(schema.clients)
-      .set({ ...next, updatedAt: new Date() })
+      .set({
+        name: next.name,
+        nationality: next.nationality,
+        lastClub: next.lastClub,
+        heightCm: next.heightCm,
+        categoryId: next.categoryId,
+        presentationImageUrl: next.presentationImageUrl,
+        eurobasketLink: next.eurobasketLink,
+        updatedAt: new Date(),
+      })
       .where(eq(schema.clients.id, id));
   } catch (error) {
     if (isForeignKeyViolation(error)) {
@@ -312,6 +321,18 @@ export async function removePlayerVideo(
   playerId: string,
   videoId: string,
 ): Promise<void> {
+  const existing = await getPlayer(db, playerId);
+  const nextVideos = existing?.videos.filter((video) => video.id !== videoId);
+  if (
+    existing?.visibility === "public" &&
+    nextVideos &&
+    !isPlayerComplete({ ...existing, videos: nextVideos })
+  ) {
+    throw new ConflictError(
+      "A Player cannot be public unless the profile is complete.",
+    );
+  }
+
   const [row] = await db
     .delete(schema.playerVideos)
     .where(
@@ -419,13 +440,6 @@ export async function clearPresentationImage(
     columns: {
       id: true,
       kind: true,
-      name: true,
-      nationality: true,
-      lastClub: true,
-      visibility: true,
-      heightCm: true,
-      categoryId: true,
-      presentationImageUrl: true,
       presentationImageKey: true,
     },
     where: and(
@@ -439,14 +453,31 @@ export async function clearPresentationImage(
   }
 
   if (existing.kind === "player") {
-    const next = {
-      ...existing,
-      presentationImageUrl: null,
-    };
+    const player = await getPlayer(db, clientId);
+    if (!player) {
+      throw new NotFoundError("Player");
+    }
 
-    if (existing.visibility === "public" && !isPlayerComplete(next)) {
+    if (
+      player.visibility === "public" &&
+      !isPlayerComplete({ ...player, presentationImageUrl: null })
+    ) {
       throw new ConflictError(
         "A Player cannot be public unless the profile is complete.",
+      );
+    }
+  } else {
+    const coach = await getCoach(db, clientId);
+    if (!coach) {
+      throw new NotFoundError("Coach");
+    }
+
+    if (
+      coach.visibility === "public" &&
+      !isCoachComplete({ ...coach, presentationImageUrl: null })
+    ) {
+      throw new ConflictError(
+        "A Coach cannot be public unless the profile is complete.",
       );
     }
   }
@@ -530,7 +561,7 @@ export async function addPlayerGalleryImage(
 
 export async function removePlayerGalleryImage(
   db: Database,
-  playerId: string,
+  clientId: string,
   imageId: string,
   deleteBlobs: DeleteBlobs,
 ): Promise<void> {
@@ -541,12 +572,38 @@ export async function removePlayerGalleryImage(
     },
     where: and(
       eq(schema.playerGalleryImages.id, imageId),
-      eq(schema.playerGalleryImages.clientId, playerId),
+      eq(schema.playerGalleryImages.clientId, clientId),
     ),
   });
 
   if (!image) {
     throw new NotFoundError("Image");
+  }
+
+  const player = await getPlayer(db, clientId);
+  if (player) {
+    const nextGallery = player.gallery.filter((item) => item.id !== imageId);
+    if (
+      player.visibility === "public" &&
+      !isPlayerComplete({ ...player, gallery: nextGallery })
+    ) {
+      throw new ConflictError(
+        "A Player cannot be public unless the profile is complete.",
+      );
+    }
+  } else {
+    const coach = await getCoach(db, clientId);
+    if (coach) {
+      const nextGallery = coach.gallery.filter((item) => item.id !== imageId);
+      if (
+        coach.visibility === "public" &&
+        !isCoachComplete({ ...coach, gallery: nextGallery })
+      ) {
+        throw new ConflictError(
+          "A Coach cannot be public unless the profile is complete.",
+        );
+      }
+    }
   }
 
   await db

--- a/apps/dashboard/src/utils/trash.test.ts
+++ b/apps/dashboard/src/utils/trash.test.ts
@@ -7,9 +7,15 @@ import { eq, sql } from "drizzle-orm";
 import { createDatabase, listPublicRosterPlayers, schema } from "@dtm/database";
 
 import { createCategory } from "./categories";
-import { createCoach, getCoach, setCoachVisibility } from "./coaches";
+import { createCoach, getCoach } from "./coaches";
 import { NotFoundError } from "./errors";
-import { createPlayer, getPlayer, setPlayerVisibility } from "./players";
+import {
+  addPlayerGalleryImage,
+  addPlayerVideo,
+  createPlayer,
+  getPlayer,
+  setPlayerVisibility,
+} from "./players";
 import {
   deleteClientFromTrash,
   restoreClient,
@@ -63,7 +69,22 @@ async function completePublicPlayer() {
     heightCm: 198,
     categoryId: category.id,
     presentationImageUrl: "https://example.com/manu.jpg",
+    eurobasketLink: "https://basketball.eurobasket.com/player/Manu-Ginobili/1",
   });
+  await addPlayerVideo(
+    db,
+    player.id,
+    "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  );
+  await addPlayerGalleryImage(
+    db,
+    player.id,
+    {
+      url: "https://example.com/gallery.jpg",
+      pathname: `players/${player.id}/gallery/1.jpg`,
+    },
+    async () => {},
+  );
   return setPlayerVisibility(db, player.id, "public");
 }
 
@@ -153,8 +174,6 @@ test("trashing a Player does not trash a Coach", async () => {
 
 test("a private Client stays private after restore", async () => {
   const coach = await createCoach(db, coachInput());
-  await setCoachVisibility(db, coach.id, "public");
-  await setCoachVisibility(db, coach.id, "private");
 
   await trashClient(db, coach.id);
   await restoreClient(db, coach.id);


### PR DESCRIPTION
## Summary
- A Client can be public only when that kind’s profile is complete.
- A public Player now also needs an Eurobasket link, at least one gallery image, and at least one video. A public Coach now also needs a presentation image and at least one gallery image.
- Staff cannot edit a public Client into an incomplete profile (including last gallery image, last video, or presentation image). Create still leaves new Clients private; a complete Client can still be made private.

Closes #39

## Test plan
- [ ] Try to make a Player public without Eurobasket link, gallery, or videos — it is refused
- [ ] Try to make a Coach public without presentation image or gallery — it is refused
- [ ] Make a complete Player/Coach public, then try to clear required media or required facts — it is refused
- [ ] Make a complete Client private — it succeeds
- [ ] Create a new Client — it stays private and does not need a complete profile


Made with [Cursor](https://cursor.com)