### PR TITLE
Polish landing glass chrome, shapes, and Meta type

### DIFF
--- a/apps/landing/DESIGN.md
+++ b/apps/landing/DESIGN.md
@@ -1,41 +1,48 @@
 # Landing design brief
 
-**Reading this as:** redesign-preserve of DTM Ones public Roster landing for Staff and visitors, dark sports/agency language, leaning toward the Player **Info glass pill + plate** as the shared chrome dialect (not a second marketing aesthetic, not dashboard Nova).
+**Reading this as:** redesign-preserve of DTM Ones public Roster landing for Staff and visitors, dark sports/agency language, leaning toward the Player **Info glass pill + plate** as the shared chrome fill dialect (not a second marketing aesthetic, not dashboard Nova).
 
 | Dial | Value | Why |
 | --- | --- | --- |
 | `DESIGN_VARIANCE` | 6 | Editorial photography + one chrome family. Cards stay media-led. |
 | `MOTION_INTENSITY` | 5 | Short opacity / tap scale / line morph. Ease `[0.16, 1, 0.3, 1]`. No scroll hijack on chrome. |
-| `VISUAL_DENSITY` | 3 | Airy roster grid; controls stay 40px pills/icons. |
+| `VISUAL_DENSITY` | 3 | Airy roster grid; media controls 40px; header chrome 44px. |
 
 ## Goal
 
-One interactive chrome language across landing **buttons and the home search field**. Staff liked the player-page Info control; that is the reference. Roster **player cards stay media hit-targets** (no glass pills on cards).
+One interactive chrome **fill** language across landing buttons and the home search field (darker glass light, shared tokens). Shape is **role-based** (see Shape lock). Staff liked the player-page Info control fill; that is the glass reference. Roster **player cards stay media hit-targets** (no glass pills on cards).
 
-Success: header search field + filter/search openers, hamburger, player Info, Gallery/Highlights mode switch, gallery chevrons, and highlights pager share the same glass fill, border, blur, and radius rules.
+Success: header search field + filter/search openers, hamburger, player Info, Gallery/Highlights mode switch, gallery chevrons, and highlights pager share the same glass fill, border, blur rules. Header cluster uses soft-square shape; media overlays stay pill/circle.
 
 ## Canonical chrome (locked)
 
-**Reference:** `Player/Info` trigger + window. Shared CSS must stay **literal** to that trigger (same fill stack, border, blur, inset highlight, drop, hover, `:active` scale `0.98`). Do not “improve” it with background transitions or open-state border boosts.
+**Reference fill:** `Player/Info` trigger + window. Shared CSS must stay **literal** to that fill stack (same fill, border, blur, inset highlight, drop, hover, `:active` scale `0.98`). Do not “improve” it with background transitions or open-state border boosts. **Darker light:** cut white specular / border / inset; do **not** raise fill opacity to fake darker.
 
 ### Atoms
 
 | Atom | Spec | Code |
 | --- | --- | --- |
 | **Glass pill** (labeled) | Height 40px, full pill radius, icon + uppercase Inter label | `.glass-control.glass-control--pill` / `<GlassControl variant="pill">` |
-| **Glass icon** | 40×40 circle, icon only | `.glass-control.glass-control--icon` / `<GlassControl>` |
-| **Glass field** | Same shell as pill; used for the home search input | `.search-pill` |
+| **Glass icon** (media) | 40×40 circle, icon only | `.glass-control.glass-control--icon` / `<GlassControl>` |
+| **Glass soft** (header) | 44×44, radius 12px, icon only | `.glass-control.glass-control--soft` / `<GlassControl variant="soft">` |
+| **Glass field** | Same shell as soft; home search input | `.search-pill` |
 | **Glass plate** | 16px radius frosted panel (menus/windows opened by those buttons) | `.glass-plate` |
 | **Backdrop** | `rgb(0 0 0 / 0.62)` dim behind modal plates | `--glass-backdrop` |
-| **Glass track** | Darker segmented shell (ModeSwitch only) | ModeSwitch `.nav` — same border family, denser fill |
+| **Glass track** | Same glass shell as controls; pill height 40; sliding active segment (no white wipe) | ModeSwitch `.nav` / `.indicator` |
+| **Meta** | Inter 13 / 400 / tracking −0.02em / uppercase (Player card Category reference) | Header inline nav, card Category, glass labels, Info meta, filter section labels; `--meta-*` |
 
-Tokens live in `src/app/globals.css` (`--glass-*`). Prefer tokens or `GlassControl` over one-off `#1d1d1d` circles.
+Tokens live in `src/app/globals.css` (`--glass-*`, `--meta-*`). Prefer tokens or `GlassControl` over one-off `#1d1d1d` circles.
 
-### Shape lock
+### Shape lock (role-based)
 
-- Controls + search field: **full pill** (`border-radius: 999px`), height **40px**.
-- Plates/dialogs: **16px** (`--glass-plate-radius`).
-- Do not mix solid `#1d1d1d` + aureola search with glass icon buttons.
+| Role | Radius | Size |
+| --- | --- | --- |
+| Header chrome (hamburger, search/filter openers, search field) | **12px** (`--glass-soft-radius`) | **44px** tall |
+| Floating media chrome (Info pill, ModeSwitch, Play, gallery/highlights chevrons) | **999px** | 40px controls (Play is larger by design) |
+| Plates / MorphSlider caption | **16px** | — |
+| Page CTAs (Load more, Contact submit, empty Clear) | **12px** | — |
+
+Do not mix solid `#1d1d1d` + aureola search with glass controls.
 
 ### Motion / fidelity lock
 
@@ -49,28 +56,29 @@ Tokens live in `src/app/globals.css` (`--glass-*`). Prefer tokens or `GlassContr
 
 | Surface | Variant | Notes |
 | --- | --- | --- |
-| Player **Info** | Pill + plate | Reference implementation |
-| Home **search field** | Glass field (`.search-pill`) | Same shell as Info; aureola retired |
-| Player **Gallery / Highlights** mode switch | Glass track | Darker shell; GSAP wipe stays |
-| Gallery **prev/next** (`MorphSlider`) | Icon | |
-| Highlights **prev/next** | Icon | |
-| Header **mobile search** opener | Icon | Active URL badge = white dot |
-| Header **desktop filter** opener | Icon | Active when `c` / `kind` set |
-| Header **hamburger** | Icon | Below `nav` (1250) only; line morph inside glass circle (#49) |
-| Header **inline nav** | Text | `nav+` Home · About · Contact; opacity current/hover (#49) |
+| Player **Info** | Pill + plate | Fill reference; keep full pill |
+| Home **search field** | Glass field (`.search-pill`) | Soft radius 12; height 44; aureola retired |
+| Player **Gallery / Highlights** mode switch | Glass track | Same fill as controls; measured sliding thumb; no React Bits wipe |
+| Gallery **prev/next** (`MorphSlider`) | Icon (circle) | |
+| Highlights **prev/next** | Icon (circle) | |
+| Header **mobile search** opener | Soft | Active URL badge = white dot |
+| Header **desktop filter** opener | Soft | Active when `c` / `kind` set |
+| Header **hamburger** | Soft | Below `nav` (1250) only; line morph (#49) |
+| Header **inline nav** | Meta | Opacity current/hover (#49) |
 | Full-screen **site menu** | Panel | Below `nav`; glass-backed full-bleed; opacity links, no SplitLink (#49) |
-| Search/filter **overlay panel** | Plate | Companion window, not a card |
+| Search/filter **overlay panel** | Plate | Companion window; section labels = Meta |
+| Roster card **Category** | Meta | Reference for Meta |
 
 ## Where it does **not** apply
 
 | Surface | Why |
 | --- | --- |
-| Roster **player cards** | Photo navigation, not chrome buttons |
-| Filter **chips** | Choice controls inside the plate (#54) |
-| Highlights **Play** (large white circle) | Primary media CTA; keep solid high-contrast |
-| Contact submit, Load more, Clear filters, footer social | Page CTAs / quiet links; out of this pass |
-| Desktop **inline nav** links | Typographic opacity current/hover — not glass pills (#49) |
-| Full-screen **site menu** links | Same opacity language as inline; panel is glass-backed full-bleed (#49) |
+| Roster **player cards** (chrome) | Photo navigation, not chrome buttons |
+| Filter **chips** | Choice controls inside the plate (#54); keep pill |
+| Highlights **Play** (large white circle) | Primary media CTA; keep solid high-contrast circle |
+| Contact submit, Load more, Clear filters, footer social | Page CTAs / quiet links — radius 12 for solid CTAs; not glass fill |
+| Desktop **inline nav** links | Typographic Meta — not glass pills (#49) |
+| Full-screen **site menu** links | Same opacity language as inline; Big Shoulders display (#49) |
 
 ## Patterns to retire
 
@@ -81,6 +89,10 @@ Tokens live in `src/app/globals.css` (`--glass-*`). Prefer tokens or `GlassContr
 - Background transitions on glass fills.
 - Stronger border on open/`aria-expanded` (Info never did this).
 - Inventing a new button dialect per feature.
+- Twin **circle** header icons on mobile (use soft-square instead).
+- Inter meta with **wide** tracking (0.08–0.14em) on Category / nav-like labels — Category (−0.02em) is the reference.
+- Bright glass (high white specular) as the default fill.
+- ModeSwitch React Bits **white circular wipe** / black-on-white invert (too loud vs glass chrome).
 
 ## Related tickets
 

--- a/apps/landing/src/app/(site)/contact/styles.module.scss
+++ b/apps/landing/src/app/(site)/contact/styles.module.scss
@@ -232,7 +232,7 @@
   color: var(--color-black);
   background: var(--color-white);
   border: 1px solid var(--color-white);
-  border-radius: 8px;
+  border-radius: 12px;
   cursor: pointer;
   transition:
     background 0.25s ease,

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -67,36 +67,43 @@
   --color-red: #ff0000;
   --background-base: #0f0f0f;
   /* Landing glass chrome (Player Info is the reference). See apps/landing/DESIGN.md */
-  --glass-fill: rgb(15 15 15 / 0.42);
-  --glass-fill-hover: rgb(15 15 15 / 0.5);
-  --glass-fill-solid: rgb(18 18 18 / 0.94);
+  /* Darker light: less white specular, same translucency — not denser fill. */
+  --glass-fill: rgb(8 8 8 / 0.42);
+  --glass-fill-hover: rgb(8 8 8 / 0.5);
+  --glass-fill-solid: rgb(12 12 12 / 0.94);
   --glass-gradient: linear-gradient(
     135deg,
-    rgb(255 255 255 / 0.16),
-    rgb(255 255 255 / 0.04)
+    rgb(255 255 255 / 0.08),
+    rgb(255 255 255 / 0.02)
   );
   --glass-gradient-hover: linear-gradient(
     135deg,
-    rgb(255 255 255 / 0.22),
-    rgb(255 255 255 / 0.06)
+    rgb(255 255 255 / 0.11),
+    rgb(255 255 255 / 0.03)
   );
-  --glass-border: rgb(255 255 255 / 0.22);
-  --glass-border-strong: rgb(255 255 255 / 0.35);
+  --glass-border: rgb(255 255 255 / 0.12);
+  --glass-border-strong: rgb(255 255 255 / 0.2);
   --glass-blur: blur(24px) saturate(160%);
-  --glass-inset: inset 0 1px 0 rgb(255 255 255 / 0.28);
+  --glass-inset: inset 0 1px 0 rgb(255 255 255 / 0.14);
   --glass-drop: 0 10px 28px rgb(0 0 0 / 0.28);
   --glass-control-size: 40px;
+  --glass-header-control-size: 44px;
+  --glass-soft-radius: 12px;
   --glass-ease: cubic-bezier(0.16, 1, 0.3, 1);
   --glass-plate-radius: 16px;
-  --glass-plate-fill: rgb(14 14 14 / 0.88);
+  --glass-plate-fill: rgb(8 8 8 / 0.88);
   --glass-plate-gradient: linear-gradient(
     160deg,
-    rgb(255 255 255 / 0.12),
-    rgb(255 255 255 / 0.04)
+    rgb(255 255 255 / 0.06),
+    rgb(255 255 255 / 0.02)
   );
   --glass-plate-blur: blur(28px) saturate(170%);
   --glass-plate-drop: 0 24px 64px rgb(0 0 0 / 0.4);
   --glass-backdrop: rgb(0 0 0 / 0.62);
+  /* Inter meta labels — Player card Category is the reference. See DESIGN.md */
+  --meta-size: 13px;
+  --meta-weight: 400;
+  --meta-tracking: -0.02em;
   --font-anton: var(--font-big-shoulders);
   --radius: 0.5rem;
   --background: var(--color-black);
@@ -158,7 +165,7 @@ body {
   overflow-x: hidden;
 }
 
-/* Shared landing chrome controls — Player Info is the literal reference. */
+/* Shared landing chrome controls — Player Info pill is the fill reference. */
 .glass-control {
   box-sizing: border-box;
   position: relative;
@@ -173,10 +180,10 @@ body {
   background: var(--glass-gradient), var(--glass-fill);
   color: var(--color-white);
   font-family: var(--font-inter);
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
   line-height: 1;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--meta-tracking);
   text-transform: uppercase;
   cursor: pointer;
   outline: none;
@@ -214,6 +221,14 @@ body {
   padding: 0;
 }
 
+/* Header cluster: soft square (hamburger, search/filter openers). */
+.glass-control--soft {
+  width: var(--glass-header-control-size);
+  height: var(--glass-header-control-size);
+  padding: 0;
+  border-radius: var(--glass-soft-radius);
+}
+
 .glass-control--pill {
   height: var(--glass-control-size);
   padding: 0 14px 0 12px;
@@ -230,16 +245,21 @@ body {
   pointer-events: none;
 }
 
+.glass-control--soft .glass-control__badge {
+  top: 8px;
+  right: 8px;
+}
+
 .glass-plate {
   border-radius: var(--glass-plate-radius);
-  border: 1px solid rgb(255 255 255 / 0.18);
+  border: 1px solid rgb(255 255 255 / 0.1);
   background: var(--glass-plate-gradient), var(--glass-plate-fill);
   color: var(--color-white);
   isolation: isolate;
   backdrop-filter: var(--glass-plate-blur);
   -webkit-backdrop-filter: var(--glass-plate-blur);
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.22),
+    inset 0 1px 0 rgb(255 255 255 / 0.12),
     var(--glass-plate-drop);
 }
 
@@ -259,18 +279,18 @@ body {
   }
 }
 
-/* Search field uses the same glass shell as controls (no aureola). */
+/* Search field: same glass fill as controls; soft radius matches header icons. */
 .search-pill {
   box-sizing: border-box;
   position: relative;
   display: flex;
   align-items: center;
   gap: 12px;
-  height: var(--glass-control-size);
+  height: var(--glass-header-control-size);
   width: 100%;
   padding: 0 14px 0 12px;
   border: 1px solid var(--glass-border);
-  border-radius: 999px;
+  border-radius: var(--glass-soft-radius);
   background: var(--glass-gradient), var(--glass-fill);
   outline: none;
   isolation: isolate;

--- a/apps/landing/src/components/Cards/styles.module.scss
+++ b/apps/landing/src/components/Cards/styles.module.scss
@@ -59,7 +59,7 @@
   }
 
   .player_position {
-    @include type.inter(12px);
+    @include type.inter(var(--meta-size));
     text-transform: uppercase;
     opacity: 0.5;
   }

--- a/apps/landing/src/components/GlassControl.tsx
+++ b/apps/landing/src/components/GlassControl.tsx
@@ -5,7 +5,8 @@ import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 type GlassControlProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "icon" | "pill";
+  /** icon = media circle; soft = header soft-square; pill = labeled (Info). */
+  variant?: "icon" | "soft" | "pill";
   /** Filter/search URL badge (white dot). Not the same as aria-expanded. */
   active?: boolean;
   children: ReactNode;
@@ -29,7 +30,11 @@ const GlassControl = forwardRef<HTMLButtonElement, GlassControlProps>(
         type={type}
         className={cn(
           "glass-control",
-          variant === "pill" ? "glass-control--pill" : "glass-control--icon",
+          variant === "pill"
+            ? "glass-control--pill"
+            : variant === "soft"
+              ? "glass-control--soft"
+              : "glass-control--icon",
           className,
         )}
         data-active={active ? "true" : undefined}

--- a/apps/landing/src/components/Header/Filters/index.tsx
+++ b/apps/landing/src/components/Header/Filters/index.tsx
@@ -39,7 +39,7 @@ function optionClass(active: boolean) {
 }
 
 const sectionMetaClass =
-  "text-[11px] font-medium tracking-[0.14em] text-white uppercase opacity-[0.35]";
+  "text-[length:var(--meta-size)] font-normal tracking-[var(--meta-tracking)] text-white uppercase opacity-[0.35]";
 
 function SectionLabel({ children }: { children: ReactNode }) {
   return <p className={sectionMetaClass}>{children}</p>;

--- a/apps/landing/src/components/Header/InlineNav.tsx
+++ b/apps/landing/src/components/Header/InlineNav.tsx
@@ -23,7 +23,7 @@ export default function InlineNav({ className }: { className?: string }) {
             key={page.href}
             href={page.href}
             className={cn(
-              "text-sm font-medium uppercase tracking-[0.14em] text-white transition-opacity duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
+              "text-[length:var(--meta-size)] font-normal tracking-[var(--meta-tracking)] text-white uppercase transition-opacity duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]",
               isCurrent ? "opacity-100" : "opacity-[0.32] hover:opacity-100 focus-visible:opacity-100",
             )}
             aria-current={isCurrent ? "page" : undefined}

--- a/apps/landing/src/components/Header/Menu/Button/index.tsx
+++ b/apps/landing/src/components/Header/Menu/Button/index.tsx
@@ -22,6 +22,7 @@ export default function Button({
   return (
     <GlassControl
       ref={buttonRef}
+      variant="soft"
       aria-label={isActive ? "Close menu" : "Open menu"}
       aria-expanded={isActive}
       aria-controls="site-menu"

--- a/apps/landing/src/components/Header/SearchCluster/index.tsx
+++ b/apps/landing/src/components/Header/SearchCluster/index.tsx
@@ -80,6 +80,7 @@ export default function SearchCluster() {
         </div>
         {hasFilters ? (
           <GlassControl
+            variant="soft"
             aria-label={open ? "Close filters" : "Open filters"}
             aria-expanded={open}
             aria-controls={panelId}
@@ -94,6 +95,7 @@ export default function SearchCluster() {
       {/* Mobile: one control for the whole search block */}
       <div className="flex justify-end lg:hidden">
         <GlassControl
+          variant="soft"
           aria-label={open ? "Close search" : "Open search"}
           aria-expanded={open}
           aria-controls={panelId}

--- a/apps/landing/src/components/MorphSlider.tsx
+++ b/apps/landing/src/components/MorphSlider.tsx
@@ -713,7 +713,7 @@ export default function MorphSlider({
               <span
                 key={i}
                 aria-hidden={i === index ? undefined : true}
-                className={`morph-slider-caption-text pointer-events-none inline-block rounded-[10px] bg-[rgba(10,10,12,0.42)] px-[14px] py-[8px] text-[15px] font-semibold tracking-[0.01em] text-white backdrop-blur-[8px] [grid-area:1/1] [justify-self:start] [transition:opacity_var(--ms-swap)_cubic-bezier(0.16,1,0.3,1),transform_var(--ms-swap)_cubic-bezier(0.16,1,0.3,1),filter_var(--ms-swap)_cubic-bezier(0.16,1,0.3,1)] ${
+                className={`morph-slider-caption-text pointer-events-none inline-block rounded-[var(--glass-plate-radius)] bg-[rgba(10,10,12,0.42)] px-[14px] py-[8px] text-[15px] font-semibold tracking-[0.01em] text-white backdrop-blur-[8px] [grid-area:1/1] [justify-self:start] [transition:opacity_var(--ms-swap)_cubic-bezier(0.16,1,0.3,1),transform_var(--ms-swap)_cubic-bezier(0.16,1,0.3,1),filter_var(--ms-swap)_cubic-bezier(0.16,1,0.3,1)] ${
                   i === index
                     ? 'opacity-100 [transform:translateY(0)] [filter:blur(0)]'
                     : 'opacity-0 [transform:translateY(12px)] [filter:blur(6px)]'

--- a/apps/landing/src/components/Player/Highlights/styles.module.scss
+++ b/apps/landing/src/components/Player/Highlights/styles.module.scss
@@ -111,17 +111,14 @@
   backdrop-filter: var(--glass-blur);
   -webkit-backdrop-filter: var(--glass-blur);
   box-shadow: var(--glass-inset), var(--glass-drop);
-  transition:
-    background 0.2s ease,
-    border-color 0.2s ease,
-    transform 0.2s var(--glass-ease);
+  transition: transform 0.2s var(--glass-ease);
 
   &:hover {
     background: var(--glass-gradient-hover), var(--glass-fill-hover);
   }
 
   &:active {
-    transform: translateY(-50%) scale(0.96);
+    transform: translateY(-50%) scale(0.98);
   }
 
   &:focus-visible {

--- a/apps/landing/src/components/Player/Info/styles.module.scss
+++ b/apps/landing/src/components/Player/Info/styles.module.scss
@@ -30,13 +30,13 @@
   width: 100%;
   padding: 0;
   border-radius: var(--glass-plate-radius);
-  border: 1px solid rgb(255 255 255 / 0.18);
+  border: 1px solid rgb(255 255 255 / 0.1);
   background: var(--glass-plate-gradient), var(--glass-plate-fill);
   color: var(--color-white);
   backdrop-filter: var(--glass-plate-blur);
   -webkit-backdrop-filter: var(--glass-plate-blur);
   box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.22),
+    inset 0 1px 0 rgb(255 255 255 / 0.12),
     var(--glass-plate-drop);
 }
 
@@ -58,8 +58,9 @@
 .category {
   margin: 0;
   font-family: var(--font-inter);
-  font-size: 14px;
-  letter-spacing: 0.08em;
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
+  letter-spacing: var(--meta-tracking);
   text-transform: uppercase;
   color: rgb(255 255 255 / 0.55);
 }
@@ -97,8 +98,9 @@
 
 .stats dt {
   font-family: var(--font-inter);
-  font-size: 11px;
-  letter-spacing: 0.08em;
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
+  letter-spacing: var(--meta-tracking);
   text-transform: uppercase;
   color: rgb(255 255 255 / 0.48);
 }
@@ -120,9 +122,9 @@
   flex-shrink: 0;
   margin-left: auto;
   font-family: var(--font-inter);
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
+  letter-spacing: var(--meta-tracking);
   text-transform: uppercase;
   color: var(--color-white);
 }

--- a/apps/landing/src/components/Player/ModeSwitch/index.tsx
+++ b/apps/landing/src/components/Player/ModeSwitch/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { gsap } from "gsap";
-import { useReducedMotion } from "motion/react";
+import { useLayoutEffect, useRef, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
 
 import type { PlayerSectionId } from "@/components/Header/Filters/player-sections";
 
@@ -10,7 +9,7 @@ import styles from "./styles.module.scss";
 
 type Item = { id: PlayerSectionId; name: string };
 
-const ease = "power3.easeOut";
+const ease = [0.16, 1, 0.3, 1] as const;
 
 export default function PlayerModeSwitch({
   items,
@@ -22,143 +21,54 @@ export default function PlayerModeSwitch({
   onChange: (id: PlayerSectionId) => void;
 }) {
   const reduce = useReducedMotion();
-  const circleRefs = useRef<Array<HTMLSpanElement | null>>([]);
-  const labelRefs = useRef<Array<HTMLSpanElement | null>>([]);
-  const hoverLabelRefs = useRef<Array<HTMLSpanElement | null>>([]);
-  const tlRefs = useRef<Array<gsap.core.Timeline | null>>([]);
-  const tweenRefs = useRef<Array<gsap.core.Tween | null>>([]);
-  const valueRef = useRef(value);
-  valueRef.current = value;
+  const navRef = useRef<HTMLElement>(null);
+  const btnRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [thumb, setThumb] = useState({ x: 0, width: 0 });
 
-  useEffect(() => {
-    if (reduce) return;
-
-    const layout = () => {
-      circleRefs.current.forEach((circle, index) => {
-        if (!circle?.parentElement) return;
-
-        const pill = circle.parentElement;
-        const { width: w, height: h } = pill.getBoundingClientRect();
-        if (w === 0 || h === 0) return;
-
-        const R = ((w * w) / 4 + h * h) / (2 * h);
-        const D = Math.ceil(2 * R) + 2;
-        const delta =
-          Math.ceil(R - Math.sqrt(Math.max(0, R * R - (w * w) / 4))) + 1;
-        const originY = D - delta;
-
-        circle.style.width = `${D}px`;
-        circle.style.height = `${D}px`;
-        circle.style.bottom = `-${delta}px`;
-
-        gsap.set(circle, {
-          xPercent: -50,
-          scale: 0,
-          transformOrigin: `50% ${originY}px`,
-        });
-
-        const label = labelRefs.current[index];
-        const hover = hoverLabelRefs.current[index];
-        if (label) gsap.set(label, { y: 0 });
-        if (hover) gsap.set(hover, { y: h + 12, opacity: 0 });
-
-        tlRefs.current[index]?.kill();
-        const tl = gsap.timeline({ paused: true });
-        tl.to(
-          circle,
-          { scale: 1.2, xPercent: -50, duration: 2, ease, overwrite: "auto" },
-          0,
-        );
-        if (label) {
-          tl.to(
-            label,
-            { y: -(h + 8), duration: 2, ease, overwrite: "auto" },
-            0,
-          );
-        }
-        if (hover) {
-          gsap.set(hover, { y: Math.ceil(h + 100), opacity: 0 });
-          tl.to(
-            hover,
-            { y: 0, opacity: 1, duration: 2, ease, overwrite: "auto" },
-            0,
-          );
-        }
-        tlRefs.current[index] = tl;
-        tl.progress(items[index]?.id === valueRef.current ? 1 : 0);
-      });
+  useLayoutEffect(() => {
+    const sync = () => {
+      const index = items.findIndex((item) => item.id === value);
+      const btn = btnRefs.current[index];
+      if (!btn) return;
+      setThumb({ x: btn.offsetLeft, width: btn.offsetWidth });
     };
 
-    layout();
-    window.addEventListener("resize", layout);
-    const fonts = document.fonts?.ready.then(layout).catch(() => undefined);
-
+    sync();
+    const fonts = document.fonts?.ready.then(sync).catch(() => undefined);
+    window.addEventListener("resize", sync);
     return () => {
-      window.removeEventListener("resize", layout);
+      window.removeEventListener("resize", sync);
       void fonts;
-      tlRefs.current.forEach((tl) => tl?.kill());
-      tweenRefs.current.forEach((tween) => tween?.kill());
     };
-  }, [items, reduce]);
-
-  useEffect(() => {
-    if (reduce) return;
-
-    items.forEach((item, index) => {
-      const tl = tlRefs.current[index];
-      if (!tl) return;
-      tweenRefs.current[index]?.kill();
-      tweenRefs.current[index] = tl.tweenTo(
-        item.id === value ? tl.duration() : 0,
-        { duration: reduce ? 0 : 0.3, ease, overwrite: "auto" },
-      );
-    });
-  }, [items, reduce, value]);
-
-  const play = (index: number, toEnd: boolean) => {
-    if (reduce) return;
-    const tl = tlRefs.current[index];
-    if (!tl) return;
-    tweenRefs.current[index]?.kill();
-    tweenRefs.current[index] = tl.tweenTo(toEnd ? tl.duration() : 0, {
-      duration: toEnd ? 0.3 : 0.2,
-      ease,
-      overwrite: "auto",
-    });
-  };
+  }, [items, value]);
 
   return (
-    <nav className={styles.nav} aria-label="Player sections">
+    <nav ref={navRef} className={styles.nav} aria-label="Player sections">
+      <motion.span
+        className={styles.indicator}
+        aria-hidden
+        initial={false}
+        animate={{ x: thumb.x, width: thumb.width }}
+        transition={
+          reduce || thumb.width === 0
+            ? { duration: 0 }
+            : { type: "tween", duration: 0.28, ease }
+        }
+      />
       {items.map((item, index) => {
         const active = value === item.id;
         return (
           <button
             key={item.id}
+            ref={(el) => {
+              btnRefs.current[index] = el;
+            }}
             type="button"
-            className={active ? `${styles.pill} ${styles.pillActive}` : styles.pill}
+            className={styles.seg}
             aria-current={active ? "true" : undefined}
             onClick={() => onChange(item.id)}
-            onMouseEnter={() => play(index, true)}
-            onMouseLeave={() => {
-              if (valueRef.current !== item.id) play(index, false);
-            }}
           >
-            <span ref={(el) => { circleRefs.current[index] = el; }} className={styles.circle} />
-            <span className={styles.stack}>
-              <span
-                ref={(el) => { labelRefs.current[index] = el; }}
-                className={styles.label}
-              >
-                {item.name}
-              </span>
-              <span
-                ref={(el) => { hoverLabelRefs.current[index] = el; }}
-                className={styles.labelHover}
-                aria-hidden
-              >
-                {item.name}
-              </span>
-            </span>
+            <span className={styles.label}>{item.name}</span>
           </button>
         );
       })}

--- a/apps/landing/src/components/Player/ModeSwitch/styles.module.scss
+++ b/apps/landing/src/components/Player/ModeSwitch/styles.module.scss
@@ -1,91 +1,81 @@
 .nav {
+  position: relative;
   display: flex;
   align-items: stretch;
-  gap: 3px;
+  gap: 2px;
   width: fit-content;
-  height: 42px;
+  height: var(--glass-control-size);
   padding: 3px;
   pointer-events: auto;
   border-radius: 999px;
-  /* Track is a darker glass shell (pre-#53 ModeSwitch) — same family, not the labeled-pill fill. */
-  background: rgb(10 10 10 / 0.55);
   border: 1px solid var(--glass-border);
-  backdrop-filter: blur(28px) saturate(180%);
-  -webkit-backdrop-filter: blur(28px) saturate(180%);
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.18),
-    0 8px 24px rgb(0 0 0 / 0.4);
+  background: var(--glass-gradient), var(--glass-fill);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-inset), var(--glass-drop);
 }
 
-.pill {
+.indicator {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  left: 0;
+  z-index: 0;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border-strong);
+  /* Lifted plate on the track — readable without the old white wipe. */
+  background: rgb(255 255 255 / 0.14);
+  pointer-events: none;
+}
+
+.seg {
   position: relative;
-  overflow: hidden;
+  z-index: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   height: 100%;
-  padding: 0 18px;
+  padding: 0 16px;
   border: 0;
   appearance: none;
   background: transparent;
   border-radius: 999px;
   font-family: var(--font-inter);
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 0;
-  letter-spacing: 0.06em;
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
+  line-height: 1;
+  letter-spacing: var(--meta-tracking);
   text-transform: uppercase;
-  color: rgb(255 255 255 / 0.82);
+  color: var(--color-white);
   cursor: pointer;
   white-space: nowrap;
+  outline: none;
 }
 
-.pill:focus-visible {
+.seg:not([aria-current="true"]) {
+  opacity: 0.5;
+}
+
+.seg:not([aria-current="true"]):hover {
+  opacity: 1;
+}
+
+.seg:focus-visible {
   outline: 2px solid rgb(255 255 255 / 0.8);
   outline-offset: 2px;
 }
 
-.circle {
-  position: absolute;
-  left: 50%;
-  z-index: 0;
-  display: block;
-  pointer-events: none;
-  border-radius: 999px;
-  background: var(--color-white);
-  transform: translateX(-50%) scale(0);
+.seg:active {
+  transform: scale(0.98);
 }
 
-.stack {
+.label {
   position: relative;
-  z-index: 1;
-  display: inline-block;
-  line-height: 1.2;
-}
-
-.label,
-.labelHover {
-  display: inline-block;
-  line-height: 1.2;
-}
-
-.labelHover {
-  position: absolute;
-  top: 0;
-  left: 0;
-  color: #111;
-  opacity: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pillActive {
-    background: var(--color-white);
-    color: #111;
-  }
-
-  .circle,
-  .labelHover {
-    display: none;
+  .seg:active {
+    transform: none;
   }
 }
 
@@ -94,5 +84,9 @@
     background: var(--glass-fill-solid);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
+  }
+
+  .indicator {
+    background: rgb(255 255 255 / 0.16);
   }
 }

--- a/apps/landing/src/components/Player/PlayerView/styles.module.scss
+++ b/apps/landing/src/components/Player/PlayerView/styles.module.scss
@@ -39,7 +39,7 @@
 }
 
 .modeSwitch {
-  pointer-events: none;
+  pointer-events: auto;
   align-self: flex-start;
 }
 


### PR DESCRIPTION
## Summary
- Darker glass light (less white specular, same translucency) across landing chrome tokens and plates
- Soft-square 44px header controls + search field; media chrome stays pill/circle; page CTAs at 12px
- Inter Meta labels from Player card Category (13 / 400 / −0.02em); ModeSwitch remade without React Bits wipe

## Test plan
- [ ] Mobile header: hamburger + search soft-square, taps work
- [ ] Desktop: search field + filter match soft shell; Info pill still round
- [ ] Player: ModeSwitch Gallery ↔ Highlights slides and selects
- [ ] Roster card Category + inline nav share Meta weight/tracking
- [ ] Glass reads darker but still translucent on photos


Made with [Cursor](https://cursor.com)