### PR TITLE
landing: fix footer social media URLs

### DIFF
--- a/apps/landing/PRODUCT.md
+++ b/apps/landing/PRODUCT.md
@@ -54,7 +54,8 @@ FIBA-licensed agency founded in June 2000 by Gustavo Gorini, FIBA & JBA Agent (l
 - About copy with founder and FIBA facts (confirmed).
 - Logo SVGs above (confirmed identity).
 - Photography under `public/assets/images/` is not confirmed as live Client assets. Do not fabricate people, quotes, press, or case studies.
-- Instagram `@dtm_ones` and the YouTube URL in the site menu are unverified. The current YouTube channel ID matches a well-known placeholder.
+- Instagram: `https://www.instagram.com/dtm.ones/` (confirmed).
+- YouTube: `https://www.youtube.com/@dtmones6926` (confirmed).
 
 ## Product Principles
 

--- a/apps/landing/src/components/Footer/index.tsx
+++ b/apps/landing/src/components/Footer/index.tsx
@@ -9,12 +9,12 @@ import styles from "./styles.module.scss";
 const socials = [
   {
     label: "Instagram",
-    href: "https://www.instagram.com/dtm_ones/",
+    href: "https://www.instagram.com/dtm.ones/",
     Icon: InstagramLogo,
   },
   {
     label: "YouTube",
-    href: "https://www.youtube.com/channel/UC_x5XG1OV2P6yVqAlKxpw6w",
+    href: "https://www.youtube.com/@dtmones6926",
     Icon: YoutubeLogo,
   },
 ] as const;


### PR DESCRIPTION
## Summary
- Update footer Instagram link to verified `https://www.instagram.com/dtm.ones/`
- Replace placeholder YouTube channel ID with verified `https://www.youtube.com/@dtmones6926`
- Mark both URLs as confirmed in `PRODUCT.md` evidence section

Closes #58.

## Test plan
- [x] Footer Instagram `href` points to `https://www.instagram.com/dtm.ones/`
- [x] Footer YouTube `href` points to `https://www.youtube.com/@dtmones6926`
- [x] No placeholder YouTube channel ID remains
- [x] `PRODUCT.md` evidence section updated with confirmed URLs
- [x] Links still open in a new tab with `rel="noreferrer"`


Made with [Cursor](https://cursor.com)