### PR TITLE
landing: polish footer layout (#70)

### DIFF
--- a/apps/landing/src/app/(site)/about/about-view.tsx
+++ b/apps/landing/src/app/(site)/about/about-view.tsx
@@ -74,7 +74,7 @@ export default function AboutView() {
     const footer = document.querySelector("footer");
 
     const syncStage = () => {
-      const footerHeight = footer?.getBoundingClientRect().height ?? 65;
+      const footerHeight = footer?.getBoundingClientRect().height ?? 82;
       root.style.setProperty("--landing-footer-height", `${footerHeight}px`);
     };
 

--- a/apps/landing/src/app/globals.css
+++ b/apps/landing/src/app/globals.css
@@ -94,7 +94,7 @@
     var(--header-padding-top) + var(--glass-header-control-size) +
       var(--header-padding-bottom)
   );
-  --landing-footer-height: 65px;
+  --landing-footer-height: 82px;
   --roster-scroll-padding-top: calc(var(--header-height) + 32px);
   --header-search-panel-top: calc(
     var(--header-padding-top) + var(--glass-header-control-size) + 12px
@@ -202,7 +202,7 @@ body:has([data-about-stage]) .page-scroll > [data-about-stage] {
 
 @media (width < 700px) {
   :root {
-    --landing-footer-height: 100px;
+    --landing-footer-height: 112px;
   }
 }
 

--- a/apps/landing/src/components/Footer/styles.module.scss
+++ b/apps/landing/src/components/Footer/styles.module.scss
@@ -2,58 +2,68 @@
   position: relative;
   z-index: 2;
   flex-shrink: 0;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px 32px;
+  gap: 24px 40px;
   width: 100%;
-  padding: 24px 28px;
+  padding: 32px 28px;
+  border-top: 1px solid var(--glass-border);
   background: var(--color-black);
-}
-
-.copyright,
-.legalLink {
-  font-family: var(--font-inter);
-  font-size: 12px;
-  line-height: 1.4;
-  color: color-mix(in srgb, var(--color-white) 48%, transparent);
 }
 
 .copyright {
   margin: 0;
-  flex: 1 1 auto;
+  min-width: 0;
+  font-family: var(--font-inter);
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
+  line-height: 1.4;
+  letter-spacing: var(--meta-tracking);
+  color: color-mix(in srgb, var(--color-white) 32%, transparent);
 }
 
 .legal {
   display: flex;
   align-items: center;
-  gap: 28px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px 32px;
 }
 
 .legalLink {
-  transition: color 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  font-family: var(--font-inter);
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
+  line-height: 1;
+  letter-spacing: var(--meta-tracking);
+  text-transform: uppercase;
+  color: var(--color-white);
+  opacity: 0.32;
+  transition: opacity 0.3s var(--glass-ease);
 
   &:hover,
   &:focus-visible {
-    color: var(--color-white);
+    opacity: 1;
     outline: none;
   }
 
   &[aria-current="page"] {
-    color: var(--color-white);
+    opacity: 1;
   }
 }
 
 @media (width < 700px) {
   .footer {
-    flex-wrap: wrap;
-    padding: 20px 16px 28px;
-    gap: 16px 20px;
+    grid-template-columns: 1fr;
+    align-items: start;
+    gap: 20px;
+    padding: 28px 16px 36px;
   }
 
   .legal {
-    flex: 1 0 100%;
-    gap: 20px;
+    justify-content: flex-start;
+    gap: 12px 24px;
   }
 }
 

--- a/apps/landing/src/components/Footer/styles.module.scss
+++ b/apps/landing/src/components/Footer/styles.module.scss
@@ -56,13 +56,14 @@
 @media (width < 700px) {
   .footer {
     grid-template-columns: 1fr;
-    align-items: start;
+    align-items: center;
     gap: 20px;
     padding: 28px 16px 36px;
+    text-align: center;
   }
 
   .legal {
-    justify-content: flex-start;
+    justify-content: center;
     gap: 12px 24px;
   }
 }


### PR DESCRIPTION
## Summary
- Improve footer presence with grid layout, Meta typography on legal links, and a glass border-top
- Sync `--landing-footer-height` fallbacks for the About one-viewport stage
- Center footer content on mobile

Closes #70

## Test plan
- [x] Typecheck passes
- [x] Full test suite passes
- [ ] Visual check: home, About, legal pages on mobile and desktop
- [ ] About page still fits one viewport with ResizeObserver
- [ ] Footer hidden on `/roster/*` player pages


Made with [Cursor](https://cursor.com)