### PR TITLE
landing: align contact form with glass chrome (#69)

### DIFF
--- a/apps/landing/src/app/(site)/contact/contact-form.tsx
+++ b/apps/landing/src/app/(site)/contact/contact-form.tsx
@@ -38,6 +38,7 @@ export default function ContactForm() {
   } = useForm<CreateContactRequest>({
     resolver: zodResolver(createContactRequestSchema),
     defaultValues: {
+      reason: "seeking_representation",
       email: "",
       phone: "",
       message: "",

--- a/apps/landing/src/app/(site)/contact/contact-form.tsx
+++ b/apps/landing/src/app/(site)/contact/contact-form.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { motion, useReducedMotion } from "motion/react";
 import { useAction } from "next-safe-action/hooks";
 
 import { createContactRequestAction } from "@/actions/contact-requests";
@@ -14,13 +15,25 @@ import {
 
 import styles from "./styles.module.scss";
 
+const easeOut = [0.16, 1, 0.3, 1] as const;
+
+const REASON_OPTIONS = [
+  { value: "seeking_representation", label: "Seeking representation" },
+  { value: "looking_for_a_player", label: "Looking for a player" },
+] as const;
+
 export default function ContactForm() {
+  const reduce = useReducedMotion() ?? false;
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitMessage, setSubmitMessage] = useState<string | null>(null);
+  const reasonRefs = useRef<Array<HTMLLabelElement | null>>([]);
+  const [thumb, setThumb] = useState({ x: 0, width: 0 });
+
   const {
     register,
     handleSubmit,
     reset,
+    watch,
     formState: { errors },
   } = useForm<CreateContactRequest>({
     resolver: zodResolver(createContactRequestSchema),
@@ -30,6 +43,30 @@ export default function ContactForm() {
       message: "",
     },
   });
+
+  const reason = watch("reason");
+
+  useLayoutEffect(() => {
+    const sync = () => {
+      const index = REASON_OPTIONS.findIndex((option) => option.value === reason);
+      if (index < 0) {
+        setThumb({ x: 0, width: 0 });
+        return;
+      }
+
+      const el = reasonRefs.current[index];
+      if (!el) return;
+      setThumb({ x: el.offsetLeft, width: el.offsetWidth });
+    };
+
+    sync();
+    const fonts = document.fonts?.ready.then(sync).catch(() => undefined);
+    window.addEventListener("resize", sync);
+    return () => {
+      window.removeEventListener("resize", sync);
+      void fonts;
+    };
+  }, [reason]);
 
   const { executeAsync, isExecuting } = useAction(createContactRequestAction, {
     onSuccess: ({ data }) => {
@@ -54,28 +91,38 @@ export default function ContactForm() {
       noValidate
     >
       <fieldset className={styles.fieldset}>
-        <legend className={styles.visuallyHidden}>Inquiry type</legend>
-        <div className={styles.options}>
-          <label className={styles.option} htmlFor="contact-reason-seeking">
-            <input
-              id="contact-reason-seeking"
-              type="radio"
-              value="seeking_representation"
-              disabled={isExecuting}
-              {...register("reason")}
-            />
-            <span>Seeking representation</span>
-          </label>
-          <label className={styles.option} htmlFor="contact-reason-looking">
-            <input
-              id="contact-reason-looking"
-              type="radio"
-              value="looking_for_a_player"
-              disabled={isExecuting}
-              {...register("reason")}
-            />
-            <span>Looking for a player</span>
-          </label>
+        <legend className={styles.reasonLegend}>Inquiry type</legend>
+        <div className={styles.reasonTrack} role="presentation">
+          <motion.span
+            className={styles.reasonIndicator}
+            aria-hidden
+            initial={false}
+            animate={{ x: thumb.x, width: thumb.width }}
+            transition={
+              reduce || thumb.width === 0
+                ? { duration: 0 }
+                : { type: "tween", duration: 0.28, ease: easeOut }
+            }
+          />
+          {REASON_OPTIONS.map((option, index) => (
+            <label
+              key={option.value}
+              ref={(el) => {
+                reasonRefs.current[index] = el;
+              }}
+              className={styles.reasonOption}
+              htmlFor={`contact-reason-${option.value}`}
+            >
+              <input
+                id={`contact-reason-${option.value}`}
+                type="radio"
+                value={option.value}
+                disabled={isExecuting}
+                {...register("reason")}
+              />
+              <span>{option.label}</span>
+            </label>
+          ))}
         </div>
         {errors.reason?.message ? (
           <p className={styles.error} role="alert">
@@ -87,15 +134,17 @@ export default function ContactForm() {
       <div className={styles.row}>
         <label className={styles.field}>
           <span className={styles.label}>Email</span>
-          <input
-            type="email"
-            placeholder="you@email.com"
-            autoComplete="email"
-            aria-invalid={!!errors.email}
-            disabled={isExecuting}
-            {...register("email")}
-            className={styles.input}
-          />
+          <div className={styles.inputShell}>
+            <input
+              type="email"
+              placeholder="you@email.com"
+              autoComplete="email"
+              aria-invalid={!!errors.email}
+              disabled={isExecuting}
+              {...register("email")}
+              className={styles.input}
+            />
+          </div>
           {errors.email?.message ? (
             <p className={styles.error} role="alert">
               {errors.email.message}
@@ -105,15 +154,17 @@ export default function ContactForm() {
 
         <label className={styles.field}>
           <span className={styles.label}>Phone</span>
-          <input
-            type="tel"
-            placeholder="+1 555 000 0000"
-            autoComplete="tel"
-            aria-invalid={!!errors.phone}
-            disabled={isExecuting}
-            {...register("phone")}
-            className={styles.input}
-          />
+          <div className={styles.inputShell}>
+            <input
+              type="tel"
+              placeholder="+1 555 000 0000"
+              autoComplete="tel"
+              aria-invalid={!!errors.phone}
+              disabled={isExecuting}
+              {...register("phone")}
+              className={styles.input}
+            />
+          </div>
           {errors.phone?.message ? (
             <p className={styles.error} role="alert">
               {errors.phone.message}
@@ -124,14 +175,16 @@ export default function ContactForm() {
 
       <label className={styles.field}>
         <span className={styles.label}>Message</span>
-        <textarea
-          placeholder="Tell us what you need"
-          rows={5}
-          aria-invalid={!!errors.message}
-          disabled={isExecuting}
-          {...register("message")}
-          className={styles.textarea}
-        />
+        <div className={styles.textareaShell}>
+          <textarea
+            placeholder="Tell us what you need"
+            rows={5}
+            aria-invalid={!!errors.message}
+            disabled={isExecuting}
+            {...register("message")}
+            className={styles.textarea}
+          />
+        </div>
         {errors.message?.message ? (
           <p className={styles.error} role="alert">
             {errors.message.message}

--- a/apps/landing/src/app/(site)/contact/contact-view.tsx
+++ b/apps/landing/src/app/(site)/contact/contact-view.tsx
@@ -53,7 +53,7 @@ export default function ContactView() {
         </motion.h1>
 
         <motion.div
-          className={`${styles.formStage} glass-plate`}
+          className={styles.formStage}
           variants={reduce ? undefined : itemVariants}
         >
           <ContactForm />

--- a/apps/landing/src/app/(site)/contact/contact-view.tsx
+++ b/apps/landing/src/app/(site)/contact/contact-view.tsx
@@ -53,7 +53,7 @@ export default function ContactView() {
         </motion.h1>
 
         <motion.div
-          className={styles.formStage}
+          className={`${styles.formStage} glass-plate`}
           variants={reduce ? undefined : itemVariants}
         >
           <ContactForm />

--- a/apps/landing/src/app/(site)/contact/styles.module.scss
+++ b/apps/landing/src/app/(site)/contact/styles.module.scss
@@ -47,8 +47,6 @@
 .formStage {
   width: min(100%, 560px);
   margin-left: clamp(48px, calc(48px + (100vw - 1200px) * 0.08), 160px);
-  padding: clamp(24px, 4cqi, 32px);
-  box-sizing: border-box;
 }
 
 .form {
@@ -68,7 +66,7 @@
 }
 
 .reasonLegend {
-  margin: 0;
+  margin: 0 0 6px;
   font-family: var(--font-inter);
   font-size: var(--meta-size);
   font-weight: var(--meta-weight);
@@ -86,7 +84,7 @@
   width: 100%;
   height: var(--glass-control-size);
   padding: 3px;
-  border-radius: 999px;
+  border-radius: var(--glass-soft-radius);
   border: 1px solid var(--glass-border);
   background: var(--glass-gradient), var(--glass-fill);
   backdrop-filter: var(--glass-blur);
@@ -100,7 +98,7 @@
   bottom: 3px;
   left: 0;
   z-index: 0;
-  border-radius: 999px;
+  border-radius: calc(var(--glass-soft-radius) - 3px);
   border: 1px solid var(--glass-border-strong);
   background: rgb(255 255 255 / 0.14);
   pointer-events: none;
@@ -146,7 +144,7 @@
   &:has(input:focus-visible) {
     outline: 2px solid rgb(255 255 255 / 0.8);
     outline-offset: 2px;
-    border-radius: 999px;
+    border-radius: var(--glass-soft-radius);
   }
 
   &:has(input:disabled) {
@@ -257,37 +255,36 @@
 
 .button {
   width: 100%;
-  padding: 16px 28px;
-  font-family: var(--font-big-shoulders);
-  font-size: 16px;
-  font-weight: 800;
-  letter-spacing: 0.08em;
+  height: var(--glass-header-control-size);
+  padding: 0 20px;
+  font-family: var(--font-inter);
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
+  letter-spacing: var(--meta-tracking);
   text-transform: uppercase;
-  color: var(--color-black);
-  background: var(--color-white);
-  border: 1px solid var(--color-white);
+  color: var(--color-white);
+  border: 1px solid var(--glass-border);
   border-radius: var(--glass-soft-radius);
+  background: var(--glass-gradient), var(--glass-fill);
+  isolation: isolate;
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-inset), var(--glass-drop);
   cursor: pointer;
-  transition:
-    background 0.25s var(--glass-ease),
-    color 0.25s var(--glass-ease),
-    border-color 0.25s var(--glass-ease);
+  transition: transform 0.2s var(--glass-ease);
 
   &:hover:not(:disabled) {
-    background: transparent;
-    color: var(--color-white);
+    background: var(--glass-gradient-hover), var(--glass-fill-hover);
   }
 
   &:disabled {
-    color: color-mix(in srgb, var(--color-black) 45%, transparent);
-    background: color-mix(in srgb, var(--color-white) 35%, transparent);
-    border-color: transparent;
+    opacity: 0.5;
     cursor: not-allowed;
   }
 
   &:focus-visible {
-    outline: 1px solid color-mix(in srgb, var(--color-white) 35%, transparent);
-    outline-offset: 3px;
+    outline: 2px solid rgb(255 255 255 / 0.8);
+    outline-offset: 2px;
   }
 
   &:active:not(:disabled) {
@@ -323,7 +320,8 @@
 @media (prefers-reduced-transparency: reduce) {
   .reasonTrack,
   .inputShell,
-  .textareaShell {
+  .textareaShell,
+  .button {
     background: var(--glass-fill-solid);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
@@ -371,10 +369,6 @@
     padding-right: 16px;
     justify-content: flex-start;
     gap: 36px;
-  }
-
-  .formStage {
-    padding: 20px 16px;
   }
 
   .row {

--- a/apps/landing/src/app/(site)/contact/styles.module.scss
+++ b/apps/landing/src/app/(site)/contact/styles.module.scss
@@ -28,7 +28,6 @@
   align-items: flex-start;
   justify-content: center;
   gap: 52px;
-  background: var(--color-black);
   container-type: inline-size;
 }
 
@@ -48,13 +47,15 @@
 .formStage {
   width: min(100%, 560px);
   margin-left: clamp(48px, calc(48px + (100vw - 1200px) * 0.08), 160px);
+  padding: clamp(24px, 4cqi, 32px);
+  box-sizing: border-box;
 }
 
 .form {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 36px;
+  gap: 28px;
 }
 
 .fieldset {
@@ -63,39 +64,58 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
-.visuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+.reasonLegend {
+  margin: 0;
+  font-family: var(--font-inter);
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
+  letter-spacing: var(--meta-tracking);
+  text-transform: uppercase;
+  color: var(--color-white);
+  opacity: 0.35;
 }
 
-.options {
-  width: 100%;
-  display: flex;
-  border-bottom: 1px solid
-    color-mix(in srgb, var(--color-white) 20%, transparent);
-}
-
-.option {
+.reasonTrack {
   position: relative;
-  width: 100%;
   display: flex;
-  justify-content: center;
+  align-items: stretch;
+  gap: 2px;
+  width: 100%;
+  height: var(--glass-control-size);
+  padding: 3px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-gradient), var(--glass-fill);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-inset), var(--glass-drop);
+}
+
+.reasonIndicator {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  left: 0;
+  z-index: 0;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border-strong);
+  background: rgb(255 255 255 / 0.14);
+  pointer-events: none;
+}
+
+.reasonOption {
+  position: relative;
+  z-index: 1;
+  flex: 1 1 0;
+  display: flex;
   align-items: center;
-  padding: 12px 0;
-  margin-bottom: -1px;
+  justify-content: center;
+  min-width: 0;
+  padding: 0 10px;
   cursor: pointer;
-  border-bottom: 2px solid transparent;
-  transition: border-color 0.2s ease;
 
   input {
     position: absolute;
@@ -104,71 +124,105 @@
   }
 
   span {
-    font-family: var(--font-big-shoulders);
-    font-size: clamp(14px, 2.5cqi, 18px);
-    font-weight: 700;
-    letter-spacing: 0.04em;
+    font-family: var(--font-inter);
+    font-size: var(--meta-size);
+    font-weight: var(--meta-weight);
+    line-height: 1.2;
+    letter-spacing: var(--meta-tracking);
     text-transform: uppercase;
-    color: var(--color-white);
-    opacity: 0.45;
     text-align: center;
-    transition: opacity 0.2s ease;
+    color: var(--color-white);
+    opacity: 0.5;
   }
 
-  &:hover {
-    border-bottom-color: color-mix(in srgb, var(--color-white) 50%, transparent);
-
-    span {
-      opacity: 0.75;
-    }
+  &:hover span {
+    opacity: 1;
   }
 
-  &:has(input:checked) {
-    border-bottom-color: var(--color-white);
-
-    span {
-      opacity: 1;
-    }
+  &:has(input:checked) span {
+    opacity: 1;
   }
 
   &:has(input:focus-visible) {
-    outline: 1px solid color-mix(in srgb, var(--color-white) 35%, transparent);
-    outline-offset: 4px;
-    border-radius: 4px;
+    outline: 2px solid rgb(255 255 255 / 0.8);
+    outline-offset: 2px;
+    border-radius: 999px;
   }
 
   &:has(input:disabled) {
     opacity: 0.5;
     cursor: not-allowed;
   }
+
+  &:active {
+    transform: scale(0.98);
+  }
 }
 
 .row {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 20px;
+  gap: 16px;
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
   min-width: 0;
 }
 
 .label {
-  font-family: var(--font-big-shoulders);
-  font-size: 13px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  font-family: var(--font-inter);
+  font-size: var(--meta-size);
+  font-weight: var(--meta-weight);
+  letter-spacing: var(--meta-tracking);
   text-transform: uppercase;
   color: var(--color-white);
+  opacity: 0.35;
+}
+
+.inputShell,
+.textareaShell {
+  box-sizing: border-box;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--glass-soft-radius);
+  background: var(--glass-gradient), var(--glass-fill);
+  isolation: isolate;
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-inset), var(--glass-drop);
+
+  &:focus-within {
+    border-color: var(--glass-border-strong);
+    background: var(--glass-gradient-hover), var(--glass-fill-hover);
+  }
+
+  &:has([aria-invalid="true"]) {
+    border-color: var(--color-red);
+  }
+
+  &:has(:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.inputShell {
+  display: flex;
+  align-items: center;
+  height: var(--glass-header-control-size);
+  padding: 0 14px;
+}
+
+.textareaShell {
+  padding: 12px 14px;
 }
 
 .input,
 .textarea {
   width: 100%;
-  padding: 14px 0;
+  padding: 0;
   font-family: var(--font-inter);
   font-size: 15px;
   font-weight: 400;
@@ -177,48 +231,28 @@
   color: var(--color-white);
   background: transparent;
   border: none;
-  border-bottom: 1px solid
-    color-mix(in srgb, var(--color-white) 28%, transparent);
   border-radius: 0;
   outline: none;
-  transition: border-color 0.2s ease;
 
   &::placeholder {
-    color: color-mix(in srgb, var(--color-white) 35%, transparent);
-  }
-
-  &:hover {
-    border-bottom-color: color-mix(
-      in srgb,
-      var(--color-white) 48%,
-      transparent
-    );
-  }
-
-  &:focus {
-    border-bottom-color: var(--color-white);
+    color: color-mix(in srgb, var(--color-white) 32%, transparent);
   }
 
   &:disabled {
-    opacity: 0.5;
     cursor: not-allowed;
-  }
-
-  &[aria-invalid="true"] {
-    border-bottom-color: var(--color-red);
   }
 }
 
 .textarea {
   resize: vertical;
-  min-height: 132px;
+  min-height: 120px;
 }
 
 .actions {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  margin-top: 8px;
+  gap: 12px;
+  margin-top: 4px;
 }
 
 .button {
@@ -232,12 +266,12 @@
   color: var(--color-black);
   background: var(--color-white);
   border: 1px solid var(--color-white);
-  border-radius: 12px;
+  border-radius: var(--glass-soft-radius);
   cursor: pointer;
   transition:
-    background 0.25s ease,
-    color 0.25s ease,
-    border-color 0.25s ease;
+    background 0.25s var(--glass-ease),
+    color 0.25s var(--glass-ease),
+    border-color 0.25s var(--glass-ease);
 
   &:hover:not(:disabled) {
     background: transparent;
@@ -254,6 +288,10 @@
   &:focus-visible {
     outline: 1px solid color-mix(in srgb, var(--color-white) 35%, transparent);
     outline-offset: 3px;
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.98);
   }
 }
 
@@ -273,6 +311,27 @@
 
 .success {
   color: color-mix(in srgb, var(--color-white) 72%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reasonOption:active,
+  .button:active:not(:disabled) {
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .reasonTrack,
+  .inputShell,
+  .textareaShell {
+    background: var(--glass-fill-solid);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .reasonIndicator {
+    background: rgb(255 255 255 / 0.16);
+  }
 }
 
 @media (width < 1200px) {
@@ -314,8 +373,16 @@
     gap: 36px;
   }
 
+  .formStage {
+    padding: 20px 16px;
+  }
+
   .row {
     grid-template-columns: 1fr;
-    gap: 36px;
+    gap: 28px;
+  }
+
+  .reasonOption span {
+    font-size: 11px;
   }
 }


### PR DESCRIPTION
## Summary
- Apply landing glass chrome to the contact form: glass track for inquiry type, glass field shells for inputs, and glass submit button
- Default inquiry type to seeking representation so the track indicator renders on load
- Match inquiry toggle radius and spacing to other form controls; no frosted plate wrapper around the full form

## Test plan
- [x] Typecheck landing app
- [x] Full test suite passes
- [ ] Contact form looks correct on desktop (with dunk photo) and mobile
- [ ] Inquiry type toggle indicator tracks selection
- [ ] `prefers-reduced-motion` and `prefers-reduced-transparency` respected

Closes #69

Made with [Cursor](https://cursor.com)